### PR TITLE
Perf/tasklist render optimization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "next": "14.1.3",
         "react": "^18",
         "react-dom": "^18",
-        "styled-components": "^6.1.8"
+        "styled-components": "^6.1.8",
+        "swr": "^2.3.7"
       },
       "devDependencies": {
         "@markuplint/jsx-parser": "^4.3.0",
@@ -7083,7 +7084,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -13398,6 +13398,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.7.tgz",
+      "integrity": "sha512-ZEquQ82QvalqTxhBVv/DlAg2mbmUjF4UgpPg9wwk4ufb9rQnZXh1iKyyKBqV6bQGu1Ie7L1QwSYO07qFIa1p+g==",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -13941,6 +13953,14 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "next": "14.1.3",
     "react": "^18",
     "react-dom": "^18",
-    "styled-components": "^6.1.8"
+    "styled-components": "^6.1.8",
+    "swr": "^2.3.7"
   },
   "devDependencies": {
     "@markuplint/jsx-parser": "^4.3.0",

--- a/src/__tests__/components/Details/AdminDetail.test.tsx
+++ b/src/__tests__/components/Details/AdminDetail.test.tsx
@@ -33,7 +33,7 @@ const mockProps = {
   id: '123',
   dataType: 'OK',
   reload: jest.fn(),
-  reloadCurrent: jest.fn(),
+  mutate: jest.fn(),
 };
 
 describe('AdminDetail', () => {
@@ -63,7 +63,7 @@ describe('AdminDetail', () => {
     expect(screen.queryByText('再アサイン')).not.toBeInTheDocument();
   });
 
-  it('calls reloadCurrent function when reassign button is clicked', async () => {
+  it('calls mutate function when reassign button is clicked', async () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
@@ -95,6 +95,6 @@ describe('AdminDetail', () => {
     expect(global.fetch).toHaveBeenCalledWith('/api/task/123/reassign', {
       method: 'PUT',
     });
-    expect(mockProps.reloadCurrent).toHaveBeenCalled();
+    expect(mockProps.mutate).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/components/Details/AdminDetail.test.tsx
+++ b/src/__tests__/components/Details/AdminDetail.test.tsx
@@ -33,6 +33,7 @@ const mockProps = {
   id: '123',
   dataType: 'OK',
   reload: jest.fn(),
+  reloadCurrent: jest.fn(),
 };
 
 describe('AdminDetail', () => {
@@ -62,8 +63,7 @@ describe('AdminDetail', () => {
     expect(screen.queryByText('再アサイン')).not.toBeInTheDocument();
   });
 
-  it('calls reload function when reassign button is clicked', async () => {
-    // global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+  it('calls reloadCurrent function when reassign button is clicked', async () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
@@ -95,6 +95,6 @@ describe('AdminDetail', () => {
     expect(global.fetch).toHaveBeenCalledWith('/api/task/123/reassign', {
       method: 'PUT',
     });
-    expect(mockProps.reload).toHaveBeenCalledWith('NG');
+    expect(mockProps.reloadCurrent).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/components/Details/MemberDetail.test.tsx
+++ b/src/__tests__/components/Details/MemberDetail.test.tsx
@@ -48,6 +48,7 @@ describe('MemberDetail', () => {
     url: 'https://example.com',
     date: '2023-01-01',
     reload: jest.fn(),
+    reloadCurrent: jest.fn(),
   };
 
   it('renders correctly when loaded', () => {
@@ -56,7 +57,7 @@ describe('MemberDetail', () => {
     expect(screen.getByText('Open File in New Tab')).toBeInTheDocument();
     expect(screen.getByText('振り分け日時：2023-01-01')).toBeInTheDocument();
     expect(screen.getByTestId('comment-list')).toBeInTheDocument();
-    expect(screen.getByText('Complete')).toBeInTheDocument();
+    expect(screen.getByText('完了')).toBeInTheDocument();
     expect(screen.getByText('NG')).toBeInTheDocument();
   });
 
@@ -66,16 +67,16 @@ describe('MemberDetail', () => {
     expect(screen.getByTestId('load-circle')).toBeInTheDocument();
   });
 
-  it('calls changeComplete when Complete button is clicked', async () => {
+  it('calls changeComplete when 完了 button is clicked', async () => {
     render(<MemberDetail {...mockProps} />);
 
-    fireEvent.click(screen.getByText('Complete'));
+    fireEvent.click(screen.getByText('完了'));
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith('/api/task/1/complete', {
         method: 'PUT',
       });
-      expect(mockProps.reload).toHaveBeenCalledWith('active');
+      expect(mockProps.reloadCurrent).toHaveBeenCalled();
     });
   });
 
@@ -88,7 +89,7 @@ describe('MemberDetail', () => {
       expect(global.fetch).toHaveBeenCalledWith('/api/task/1/ng', {
         method: 'PUT',
       });
-      expect(mockProps.reload).toHaveBeenCalledWith('active');
+      expect(mockProps.reloadCurrent).toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/components/Details/MemberDetail.test.tsx
+++ b/src/__tests__/components/Details/MemberDetail.test.tsx
@@ -48,7 +48,7 @@ describe('MemberDetail', () => {
     url: 'https://example.com',
     date: '2023-01-01',
     reload: jest.fn(),
-    reloadCurrent: jest.fn(),
+    mutate: jest.fn(),
   };
 
   it('renders correctly when loaded', () => {
@@ -76,7 +76,7 @@ describe('MemberDetail', () => {
       expect(global.fetch).toHaveBeenCalledWith('/api/task/1/complete', {
         method: 'PUT',
       });
-      expect(mockProps.reloadCurrent).toHaveBeenCalled();
+      expect(mockProps.mutate).toHaveBeenCalled();
     });
   });
 
@@ -89,7 +89,7 @@ describe('MemberDetail', () => {
       expect(global.fetch).toHaveBeenCalledWith('/api/task/1/ng', {
         method: 'PUT',
       });
-      expect(mockProps.reloadCurrent).toHaveBeenCalled();
+      expect(mockProps.mutate).toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/components/TaskAccordion.test.tsx
+++ b/src/__tests__/components/TaskAccordion.test.tsx
@@ -26,13 +26,13 @@ const mockTask: Task = {
 };
 
 const mockReload = jest.fn();
-const mockReloadCurrent = jest.fn();
+const mockMutate = jest.fn();
 
 describe('TaskAccordion', () => {
   beforeEach(() => {
     mockFetch.mockClear();
     mockReload.mockClear();
-    mockReloadCurrent.mockClear();
+    mockMutate.mockClear();
   });
 
   test('renders TaskAccordion correctly', () => {
@@ -44,7 +44,7 @@ describe('TaskAccordion', () => {
         type="member"
         dataType="test"
         reload={mockReload}
-        reloadCurrent={mockReloadCurrent}
+        mutate={mockMutate}
       />,
     );
 
@@ -68,7 +68,7 @@ describe('TaskAccordion', () => {
         type="member"
         dataType="test"
         reload={mockReload}
-        reloadCurrent={mockReloadCurrent}
+        mutate={mockMutate}
       />,
     );
 
@@ -97,7 +97,7 @@ describe('TaskAccordion', () => {
         type="member"
         dataType="test"
         reload={mockReload}
-        reloadCurrent={mockReloadCurrent}
+        mutate={mockMutate}
       />,
     );
 
@@ -114,7 +114,7 @@ describe('TaskAccordion', () => {
         type="admin"
         dataType="test"
         reload={mockReload}
-        reloadCurrent={mockReloadCurrent}
+        mutate={mockMutate}
       />,
     );
 

--- a/src/__tests__/components/TaskAccordion.test.tsx
+++ b/src/__tests__/components/TaskAccordion.test.tsx
@@ -26,11 +26,13 @@ const mockTask: Task = {
 };
 
 const mockReload = jest.fn();
+const mockReloadCurrent = jest.fn();
 
 describe('TaskAccordion', () => {
   beforeEach(() => {
     mockFetch.mockClear();
     mockReload.mockClear();
+    mockReloadCurrent.mockClear();
   });
 
   test('renders TaskAccordion correctly', () => {
@@ -42,6 +44,7 @@ describe('TaskAccordion', () => {
         type="member"
         dataType="test"
         reload={mockReload}
+        reloadCurrent={mockReloadCurrent}
       />,
     );
 
@@ -65,6 +68,7 @@ describe('TaskAccordion', () => {
         type="member"
         dataType="test"
         reload={mockReload}
+        reloadCurrent={mockReloadCurrent}
       />,
     );
 
@@ -93,6 +97,7 @@ describe('TaskAccordion', () => {
         type="member"
         dataType="test"
         reload={mockReload}
+        reloadCurrent={mockReloadCurrent}
       />,
     );
 
@@ -109,6 +114,7 @@ describe('TaskAccordion', () => {
         type="admin"
         dataType="test"
         reload={mockReload}
+        reloadCurrent={mockReloadCurrent}
       />,
     );
 

--- a/src/__tests__/components/TaskList.test.tsx
+++ b/src/__tests__/components/TaskList.test.tsx
@@ -4,14 +4,13 @@ import '@testing-library/jest-dom';
 import TaskList from '@/src/components/TaskList';
 import { AccountData, Task } from '@/src/types';
 
-// Server Actionsをモック
-jest.mock('@/src/util/actions/get-member-tasks', () => ({
-  getMemberAssignTask: jest.fn(),
-}));
+// useTaskListDataをモック
+const mockMutate = jest.fn();
+const mockChangeDataType = jest.fn();
+const mockUseTaskListData = jest.fn();
 
-jest.mock('@/src/util/actions/get-tasks', () => ({
-  getAllTasks: jest.fn(),
-  getNGTasks: jest.fn(),
+jest.mock('@/src/util/hooks/useTaskListData', () => ({
+  useTaskListData: (params: unknown) => mockUseTaskListData(params),
 }));
 
 // TaskAccordionをモック
@@ -27,15 +26,6 @@ jest.mock('@/src/components/LoadCircle', () => {
     return <div data-testid="load-circle">Loading...</div>;
   };
 });
-
-import { getMemberAssignTask } from '@/src/util/actions/get-member-tasks';
-import { getAllTasks, getNGTasks } from '@/src/util/actions/get-tasks';
-
-const mockGetMemberAssignTask = getMemberAssignTask as jest.MockedFunction<
-  typeof getMemberAssignTask
->;
-const mockGetAllTasks = getAllTasks as jest.MockedFunction<typeof getAllTasks>;
-const mockGetNGTasks = getNGTasks as jest.MockedFunction<typeof getNGTasks>;
 
 const mockMemberAccount: AccountData = {
   id: 1,
@@ -74,65 +64,92 @@ const mockTasks: Task[] = [
 
 describe('TaskList', () => {
   beforeEach(() => {
-    mockGetMemberAssignTask.mockClear();
-    mockGetAllTasks.mockClear();
-    mockGetNGTasks.mockClear();
+    mockMutate.mockClear();
+    mockChangeDataType.mockClear();
+    mockUseTaskListData.mockClear();
   });
 
   test('renders TaskList for member and fetches member tasks', async () => {
-    mockGetMemberAssignTask.mockResolvedValueOnce(mockTasks);
+    mockUseTaskListData.mockReturnValue({
+      data: mockTasks,
+      dataType: 'active',
+      isLoading: false,
+      error: null,
+      changeDataType: mockChangeDataType,
+      mutate: mockMutate,
+    });
 
     render(<TaskList id={1} account={mockMemberAccount} />);
 
     await waitFor(() => {
-      expect(mockGetMemberAssignTask).toHaveBeenCalledWith('1', expect.any(AbortSignal));
+      expect(mockUseTaskListData).toHaveBeenCalledWith({
+        account: mockMemberAccount,
+        id: 1,
+      });
     });
   });
 
   test('renders TaskList for admin and fetches all tasks', async () => {
-    mockGetAllTasks.mockResolvedValueOnce(mockTasks);
+    mockUseTaskListData.mockReturnValue({
+      data: mockTasks,
+      dataType: 'active',
+      isLoading: false,
+      error: null,
+      changeDataType: mockChangeDataType,
+      mutate: mockMutate,
+    });
 
     render(<TaskList id={2} account={mockAdminAccount} />);
 
     await waitFor(() => {
-      expect(mockGetAllTasks).toHaveBeenCalledWith(expect.any(AbortSignal));
+      expect(mockUseTaskListData).toHaveBeenCalledWith({
+        account: mockAdminAccount,
+        id: 2,
+      });
     });
   });
 
-  test('displays loading indicator when no data', async () => {
-    mockGetMemberAssignTask.mockResolvedValueOnce([]);
+  test('displays loading indicator when loading', async () => {
+    mockUseTaskListData.mockReturnValue({
+      data: [],
+      dataType: 'active',
+      isLoading: true,
+      error: null,
+      changeDataType: mockChangeDataType,
+      mutate: mockMutate,
+    });
 
     render(<TaskList id={1} account={mockMemberAccount} />);
 
-    // ロード中のインジケータが表示されることを確認
     expect(screen.getByTestId('load-circle')).toBeInTheDocument();
-
-    await waitFor(() => {
-      expect(mockGetMemberAssignTask).toHaveBeenCalledWith(
-        '1',
-        expect.any(AbortSignal),
-      );
-    });
   });
 
   test('handles fetch error gracefully', async () => {
-    const consoleErrorSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
-
-    mockGetMemberAssignTask.mockRejectedValueOnce(new Error('Fetch failed'));
+    mockUseTaskListData.mockReturnValue({
+      data: [],
+      dataType: 'active',
+      isLoading: false,
+      error: 'タスクの取得に失敗しました',
+      changeDataType: mockChangeDataType,
+      mutate: mockMutate,
+    });
 
     render(<TaskList id={1} account={mockMemberAccount} />);
 
     await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(screen.getByText('タスクの取得に失敗しました')).toBeInTheDocument();
     });
-
-    consoleErrorSpy.mockRestore();
   });
 
   test('displays tasks after loading', async () => {
-    mockGetMemberAssignTask.mockResolvedValueOnce(mockTasks);
+    mockUseTaskListData.mockReturnValue({
+      data: mockTasks,
+      dataType: 'active',
+      isLoading: false,
+      error: null,
+      changeDataType: mockChangeDataType,
+      mutate: mockMutate,
+    });
 
     render(<TaskList id={1} account={mockMemberAccount} />);
 
@@ -143,31 +160,50 @@ describe('TaskList', () => {
   });
 
   test('admin can see NG button group', async () => {
-    mockGetAllTasks.mockResolvedValueOnce(mockTasks);
+    mockUseTaskListData.mockReturnValue({
+      data: mockTasks,
+      dataType: 'active',
+      isLoading: false,
+      error: null,
+      changeDataType: mockChangeDataType,
+      mutate: mockMutate,
+    });
 
     render(<TaskList id={2} account={mockAdminAccount} />);
 
     await waitFor(() => {
-      // admin用のNGボタンが存在することを確認
       expect(screen.getByText('NG')).toBeInTheDocument();
     });
   });
 
   test('member cannot see NG button group', async () => {
-    mockGetMemberAssignTask.mockResolvedValueOnce(mockTasks);
+    mockUseTaskListData.mockReturnValue({
+      data: mockTasks,
+      dataType: 'active',
+      isLoading: false,
+      error: null,
+      changeDataType: mockChangeDataType,
+      mutate: mockMutate,
+    });
 
     render(<TaskList id={1} account={mockMemberAccount} />);
 
     await waitFor(() => {
-      expect(mockGetMemberAssignTask).toHaveBeenCalled();
+      expect(mockUseTaskListData).toHaveBeenCalled();
     });
 
-    // member用にはNGボタンが存在しないことを確認
     expect(screen.queryByRole('button', { name: 'NG' })).not.toBeInTheDocument();
   });
 
   test('switches sort type', async () => {
-    mockGetMemberAssignTask.mockResolvedValueOnce(mockTasks);
+    mockUseTaskListData.mockReturnValue({
+      data: mockTasks,
+      dataType: 'active',
+      isLoading: false,
+      error: null,
+      changeDataType: mockChangeDataType,
+      mutate: mockMutate,
+    });
 
     render(<TaskList id={1} account={mockMemberAccount} />);
 
@@ -175,10 +211,8 @@ describe('TaskList', () => {
       expect(screen.getByText('Task 1')).toBeInTheDocument();
     });
 
-    // 地域ボタンをクリック
     fireEvent.click(screen.getByText('地域'));
 
-    // ソートタイプが変更されたことを確認（ボタンがdisabledになる）
     expect(screen.getByText('地域')).toBeDisabled();
   });
 });

--- a/src/__tests__/components/TaskList.test.tsx
+++ b/src/__tests__/components/TaskList.test.tsx
@@ -85,7 +85,7 @@ describe('TaskList', () => {
     render(<TaskList id={1} account={mockMemberAccount} />);
 
     await waitFor(() => {
-      expect(mockGetMemberAssignTask).toHaveBeenCalledWith('1');
+      expect(mockGetMemberAssignTask).toHaveBeenCalledWith('1', expect.any(AbortSignal));
     });
   });
 
@@ -95,7 +95,7 @@ describe('TaskList', () => {
     render(<TaskList id={2} account={mockAdminAccount} />);
 
     await waitFor(() => {
-      expect(mockGetAllTasks).toHaveBeenCalled();
+      expect(mockGetAllTasks).toHaveBeenCalledWith(expect.any(AbortSignal));
     });
   });
 
@@ -108,7 +108,10 @@ describe('TaskList', () => {
     expect(screen.getByTestId('load-circle')).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(mockGetMemberAssignTask).toHaveBeenCalled();
+      expect(mockGetMemberAssignTask).toHaveBeenCalledWith(
+        '1',
+        expect.any(AbortSignal),
+      );
     });
   });
 

--- a/src/api/get-account-tasks.ts
+++ b/src/api/get-account-tasks.ts
@@ -5,7 +5,8 @@ import { Task } from '../types';
 export const getAccountTasks = async (id: string): Promise<Task[]> => {
   try {
     const res = await fetch(`${process.env.API_HOST}/account/tasks?id=${id}`, {
-      next: { revalidate: 60 }, // 1分ごとに再検証
+      // next: { revalidate: 60 }, // 1分ごとに再検証
+      cache: 'no-store',
     });
     const result: Task[] = (await res.json()) as Task[];
     return result;

--- a/src/api/get-tasks.ts
+++ b/src/api/get-tasks.ts
@@ -4,7 +4,7 @@ import { Task } from '../types';
 
 export async function getTasks(): Promise<Task[]> {
   const res = await fetch(`${process.env.API_HOST}/tasks?type=all`, {
-    next: { revalidate: 60 }, // 1分ごとに再検証
+    cache: 'no-store',
   });
 
   if (res.ok) {

--- a/src/components/Details/AdminDetail.tsx
+++ b/src/components/Details/AdminDetail.tsx
@@ -17,6 +17,7 @@ type Props = {
   id: string;
   dataType: string;
   reload: (newDataType: string) => void;
+  reloadCurrent: () => void;
 };
 
 const AdminDetail = (props: Props) => {
@@ -24,7 +25,7 @@ const AdminDetail = (props: Props) => {
     await fetch(`/api/task/${String(props.id)}/reassign`, {
       method: 'PUT',
     });
-    props.reload(props.dataType);
+    props.reloadCurrent();
   };
 
   const onReassign = (): void => {

--- a/src/components/Details/AdminDetail.tsx
+++ b/src/components/Details/AdminDetail.tsx
@@ -17,7 +17,7 @@ type Props = {
   id: string;
   dataType: string;
   reload: (newDataType: string) => void;
-  reloadCurrent: () => void;
+  mutate: () => void;
 };
 
 const AdminDetail = (props: Props) => {
@@ -25,7 +25,7 @@ const AdminDetail = (props: Props) => {
     await fetch(`/api/task/${String(props.id)}/reassign`, {
       method: 'PUT',
     });
-    props.reloadCurrent();
+    props.mutate();
   };
 
   const onReassign = (): void => {

--- a/src/components/Details/MemberDetail.tsx
+++ b/src/components/Details/MemberDetail.tsx
@@ -19,7 +19,7 @@ type Props = {
   url: string;
   date: string;
   reload: (newDataType: string) => void;
-  reloadCurrent: () => void;
+  mutate: () => void;
 };
 
 const MemberDetail = (props: Props) => {
@@ -27,14 +27,14 @@ const MemberDetail = (props: Props) => {
     await fetch(`/api/task/${String(props.id)}/ng`, {
       method: 'PUT',
     });
-    props.reloadCurrent();
+    props.mutate();
   };
 
   const changeComplete = async () => {
     await fetch(`/api/task/${String(props.id)}/complete`, {
       method: 'PUT',
     });
-    props.reloadCurrent();
+    props.mutate();
   };
 
   const onNG = (): void => {

--- a/src/components/Details/MemberDetail.tsx
+++ b/src/components/Details/MemberDetail.tsx
@@ -19,6 +19,7 @@ type Props = {
   url: string;
   date: string;
   reload: (newDataType: string) => void;
+  reloadCurrent: () => void;
 };
 
 const MemberDetail = (props: Props) => {
@@ -26,14 +27,14 @@ const MemberDetail = (props: Props) => {
     await fetch(`/api/task/${String(props.id)}/ng`, {
       method: 'PUT',
     });
-    props.reload('active');
+    props.reloadCurrent();
   };
 
   const changeComplete = async () => {
     await fetch(`/api/task/${String(props.id)}/complete`, {
       method: 'PUT',
     });
-    props.reload('active');
+    props.reloadCurrent();
   };
 
   const onNG = (): void => {
@@ -63,7 +64,7 @@ const MemberDetail = (props: Props) => {
           cycleId={props.cycleId}
         />
       )}
-      <BasicButton onClick={onComplete} str="Complete" />
+      <BasicButton onClick={onComplete} str="完了" />
       <OutlinedButton onClick={onNG} str="NG" />
     </AccordionDetails>
   );

--- a/src/components/TaskAccordion.tsx
+++ b/src/components/TaskAccordion.tsx
@@ -20,7 +20,7 @@ type Props = {
   type: string;
   dataType: string;
   reload: (newDataType: string) => void;
-  reloadCurrent: () => void;
+  mutate: () => void;
 };
 
 const TaskAccordion = (props: Props) => {
@@ -126,8 +126,8 @@ const TaskAccordion = (props: Props) => {
             date={date.toLocaleDateString()}
             id={String(props.task.history_id)}
             isLoaded={loaded}
+            mutate={props.mutate}
             reload={props.reload}
-            reloadCurrent={props.reloadCurrent}
             url={fileUrl}
           />
         ) : (
@@ -139,8 +139,8 @@ const TaskAccordion = (props: Props) => {
             date={date.toLocaleDateString()}
             id={String(props.task.id)}
             isLoaded={loaded}
+            mutate={props.mutate}
             reload={props.reload}
-            reloadCurrent={props.reloadCurrent}
             url={fileUrl}
           />
         )}

--- a/src/components/TaskAccordion.tsx
+++ b/src/components/TaskAccordion.tsx
@@ -20,6 +20,7 @@ type Props = {
   type: string;
   dataType: string;
   reload: (newDataType: string) => void;
+  reloadCurrent: () => void;
 };
 
 const TaskAccordion = (props: Props) => {
@@ -126,6 +127,7 @@ const TaskAccordion = (props: Props) => {
             id={String(props.task.history_id)}
             isLoaded={loaded}
             reload={props.reload}
+            reloadCurrent={props.reloadCurrent}
             url={fileUrl}
           />
         ) : (
@@ -138,6 +140,7 @@ const TaskAccordion = (props: Props) => {
             id={String(props.task.id)}
             isLoaded={loaded}
             reload={props.reload}
+            reloadCurrent={props.reloadCurrent}
             url={fileUrl}
           />
         )}

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -9,7 +9,7 @@ import {
   Toolbar,
   Typography,
 } from '@mui/material';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import LoadCircle from '@/src/components/LoadCircle';
 import TaskAccordion from '@/src/components/TaskAccordion';
@@ -34,9 +34,8 @@ const sortTasks = (list: string[], sortType: string) => {
 };
 
 const TaskList = (props: Props) => {
-  const [data, setData] = useState<Task[]>([]);
   const [sortType, setSortType] = useState<string>('time');
-  const { data: fetchedData, dataType, isLoading, error, changeDataType, reloadCurrent } =
+  const { data, dataType, isLoading, error, changeDataType, reloadCurrent } =
     useTaskListData({ account: props.account, id: props.id });
 
   const onChangeType = useCallback((type: string) => {
@@ -59,11 +58,6 @@ const TaskList = (props: Props) => {
   const section = useMemo(() => {
     return sortTasks(Object.keys(mutateData), sortType);
   }, [mutateData, sortType]);
-
-  // 取得データが変わったときのみローカルstateへ反映（派生計算のため）
-  useEffect(() => {
-    setData(fetchedData);
-  }, [fetchedData]);
 
   return (
     <Box

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -10,6 +10,7 @@ import {
   Typography,
 } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRef } from 'react';
 
 import LoadCircle from '@/src/components/LoadCircle';
 import TaskAccordion from '@/src/components/TaskAccordion';
@@ -35,48 +36,47 @@ const sortTasks = (list: string[], sortType: string) => {
 };
 
 const TaskList = (props: Props) => {
+  const requestIdRef = useRef(0);
   const [data, setData] = useState<Task[]>([]);
   const [sortType, setSortType] = useState<string>('time');
   const [dataType, setDataType] = useState<string>('active');
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const getData = useCallback(
-    async () => {
+  const fetchTasks = useCallback(
+    async (targetType: 'active' | 'NG') => {
+      const currentRequestId = requestIdRef.current + 1;
+      requestIdRef.current = currentRequestId;
+      setIsLoading(true);
+      setError(null);
+
       try {
         const result =
-          props.account.role === 'member'
-            ? await getMemberAssignTask(String(props.id))
-            : await getAllTasks();
+          targetType === 'NG'
+            ? await getNGTasks()
+            : props.account.role === 'member'
+              ? await getMemberAssignTask(String(props.id))
+              : await getAllTasks();
+
+        if (requestIdRef.current !== currentRequestId) {
+          return;
+        }
         setData(result);
       } catch (err) {
+        if (requestIdRef.current !== currentRequestId) {
+          return;
+        }
         console.error('Failed to fetch task data:', err);
-        // エラー時は空配列を設定して画面が壊れるのを防ぐ
+        setError('タスクの取得に失敗しました');
         setData([]);
       } finally {
-        setIsLoading(false);
+        if (requestIdRef.current === currentRequestId) {
+          setIsLoading(false);
+        }
       }
     },
-    [props.account.role, props.id], // getDataの依存関係
+    [props.account.role, props.id],
   );
-
-  const getNG = useCallback(async () => {
-    try {
-      const result = await getNGTasks();
-      setData(result);
-    } catch (err) {
-      console.error('Failed to fetch NG tasks:', err);
-      // エラー時は空配列を設定して画面が壊れるのを防ぐ
-      setData([]);
-    } finally {
-        setIsLoading(false);
-    }
-  }, []);
-
-  const onUpdate = useCallback(() => {
-    getData()
-      .then()
-      .catch((e) => console.error(e));
-  }, [getData]);
 
   const onChangeType = useCallback((type: string) => {
     setSortType(type);
@@ -85,13 +85,11 @@ const TaskList = (props: Props) => {
   const onChangeDataType = useCallback(
     (newDataType: string) => {
       setDataType(newDataType);
-      setIsLoading(true);
-      const fetcher = newDataType === 'NG' ? getNG : getData;
-      fetcher()
+      fetchTasks(newDataType === 'NG' ? 'NG' : 'active')
         .then()
         .catch((e) => console.error(e));
     },
-    [getData, getNG],
+    [fetchTasks],
   );
 
   // dataとsortTypeからmutateDataを計算（メモ化）
@@ -106,9 +104,10 @@ const TaskList = (props: Props) => {
 
   // 初回マウント時のみデータ取得
   useEffect(() => {
-    onUpdate();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    fetchTasks('active')
+      .then()
+      .catch((e) => console.error(e));
+  }, [fetchTasks]);
 
   return (
     <Box
@@ -131,6 +130,11 @@ const TaskList = (props: Props) => {
         }}
       >
         <Toolbar />
+        {error && (
+          <Typography color="error" sx={{ mt: 1 }}>
+            {error}
+          </Typography>
+        )}
         <Box
           sx={{
             display: 'flex',

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -35,7 +35,7 @@ const sortTasks = (list: string[], sortType: string) => {
 
 const TaskList = (props: Props) => {
   const [sortType, setSortType] = useState<string>('time');
-  const { data, dataType, isLoading, error, changeDataType, reloadCurrent } =
+  const { data, dataType, isLoading, error, changeDataType, mutate } =
     useTaskListData({ account: props.account, id: props.id });
 
   const onChangeType = useCallback((type: string) => {
@@ -48,6 +48,10 @@ const TaskList = (props: Props) => {
     },
     [changeDataType],
   );
+
+  const handleMutate = useCallback(() => {
+    void mutate();
+  }, [mutate]);
 
   // dataとsortTypeからmutateDataを計算（メモ化）
   const mutateData = useMemo(() => {
@@ -158,8 +162,8 @@ const TaskList = (props: Props) => {
                   dataType={dataType}
                   index={index}
                   key={task.id}
+                  mutate={handleMutate}
                   reload={onChangeDataType}
-                  reloadCurrent={reloadCurrent}
                   task={task}
                   type={props.account.role}
                 />

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -36,7 +36,7 @@ const sortTasks = (list: string[], sortType: string) => {
 const TaskList = (props: Props) => {
   const [data, setData] = useState<Task[]>([]);
   const [sortType, setSortType] = useState<string>('time');
-  const { data: fetchedData, dataType, isLoading, error, changeDataType } =
+  const { data: fetchedData, dataType, isLoading, error, changeDataType, reloadCurrent } =
     useTaskListData({ account: props.account, id: props.id });
 
   const onChangeType = useCallback((type: string) => {
@@ -165,6 +165,7 @@ const TaskList = (props: Props) => {
                   index={index}
                   key={task.id}
                   reload={onChangeDataType}
+                  reloadCurrent={reloadCurrent}
                   task={task}
                   type={props.account.role}
                 />

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -10,15 +10,13 @@ import {
   Typography,
 } from '@mui/material';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useRef } from 'react';
 
 import LoadCircle from '@/src/components/LoadCircle';
 import TaskAccordion from '@/src/components/TaskAccordion';
 import { AccountData } from '@/src/types';
 import { Task } from '@/src/types';
-import { getMemberAssignTask } from '@/src/util/actions/get-member-tasks';
-import { getAllTasks, getNGTasks } from '@/src/util/actions/get-tasks';
 import { grouping } from '@/src/util/grouping';
+import { useTaskListData } from '@/src/util/hooks/useTaskListData';
 
 type Props = {
   id: number;
@@ -36,47 +34,10 @@ const sortTasks = (list: string[], sortType: string) => {
 };
 
 const TaskList = (props: Props) => {
-  const requestIdRef = useRef(0);
   const [data, setData] = useState<Task[]>([]);
   const [sortType, setSortType] = useState<string>('time');
-  const [dataType, setDataType] = useState<string>('active');
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchTasks = useCallback(
-    async (targetType: 'active' | 'NG') => {
-      const currentRequestId = requestIdRef.current + 1;
-      requestIdRef.current = currentRequestId;
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const result =
-          targetType === 'NG'
-            ? await getNGTasks()
-            : props.account.role === 'member'
-              ? await getMemberAssignTask(String(props.id))
-              : await getAllTasks();
-
-        if (requestIdRef.current !== currentRequestId) {
-          return;
-        }
-        setData(result);
-      } catch (err) {
-        if (requestIdRef.current !== currentRequestId) {
-          return;
-        }
-        console.error('Failed to fetch task data:', err);
-        setError('タスクの取得に失敗しました');
-        setData([]);
-      } finally {
-        if (requestIdRef.current === currentRequestId) {
-          setIsLoading(false);
-        }
-      }
-    },
-    [props.account.role, props.id],
-  );
+  const { data: fetchedData, dataType, isLoading, error, changeDataType } =
+    useTaskListData({ account: props.account, id: props.id });
 
   const onChangeType = useCallback((type: string) => {
     setSortType(type);
@@ -84,12 +45,9 @@ const TaskList = (props: Props) => {
 
   const onChangeDataType = useCallback(
     (newDataType: string) => {
-      setDataType(newDataType);
-      fetchTasks(newDataType === 'NG' ? 'NG' : 'active')
-        .then()
-        .catch((e) => console.error(e));
+      changeDataType(newDataType === 'NG' ? 'NG' : 'active');
     },
-    [fetchTasks],
+    [changeDataType],
   );
 
   // dataとsortTypeからmutateDataを計算（メモ化）
@@ -102,12 +60,10 @@ const TaskList = (props: Props) => {
     return sortTasks(Object.keys(mutateData), sortType);
   }, [mutateData, sortType]);
 
-  // 初回マウント時のみデータ取得
+  // 取得データが変わったときのみローカルstateへ反映（派生計算のため）
   useEffect(() => {
-    fetchTasks('active')
-      .then()
-      .catch((e) => console.error(e));
-  }, [fetchTasks]);
+    setData(fetchedData);
+  }, [fetchedData]);
 
   return (
     <Box

--- a/src/util/actions/get-member-tasks.ts
+++ b/src/util/actions/get-member-tasks.ts
@@ -8,7 +8,7 @@ export const getMemberAssignTask = async (
     const res = await fetch(`/api/account/${id}/tasks`, {
       method: 'GET',
       signal,
-      next: { revalidate: 60 }, // 1分ごとに再検証
+      cache: 'no-store',
     });
     const result: Task[] = (await res.json()) as Task[];
     return result;

--- a/src/util/actions/get-member-tasks.ts
+++ b/src/util/actions/get-member-tasks.ts
@@ -1,9 +1,13 @@
 import { Task } from '@/src/types';
 
-export const getMemberAssignTask = async (id: string): Promise<Task[]> => {
+export const getMemberAssignTask = async (
+  id: string,
+  signal?: AbortSignal,
+): Promise<Task[]> => {
   try {
     const res = await fetch(`/api/account/${id}/tasks`, {
       method: 'GET',
+      signal,
       next: { revalidate: 60 }, // 1分ごとに再検証
     });
     const result: Task[] = (await res.json()) as Task[];

--- a/src/util/actions/get-tasks.ts
+++ b/src/util/actions/get-tasks.ts
@@ -1,9 +1,10 @@
 import { Task } from '@/src/types';
 
-export const getAllTasks = async (): Promise<Task[]> => {
+export const getAllTasks = async (signal?: AbortSignal): Promise<Task[]> => {
   try {
     const res = await fetch(`/api/tasks/all?type=all`, {
       method: 'GET',
+      signal,
       next: { revalidate: 60 }, // 1分ごとに再検証
     });
     const result: Task[] = (await res.json()) as Task[];
@@ -14,10 +15,11 @@ export const getAllTasks = async (): Promise<Task[]> => {
   }
 };
 
-export const getNGTasks = async (): Promise<Task[]> => {
+export const getNGTasks = async (signal?: AbortSignal): Promise<Task[]> => {
   try {
     const res = await fetch(`/api/tasks/ng`, {
       method: 'GET',
+      signal,
       next: { revalidate: 60 }, // 1分ごとに再検証
     });
     const result: Task[] = (await res.json()) as Task[];

--- a/src/util/actions/get-tasks.ts
+++ b/src/util/actions/get-tasks.ts
@@ -5,7 +5,7 @@ export const getAllTasks = async (signal?: AbortSignal): Promise<Task[]> => {
     const res = await fetch(`/api/tasks/all?type=all`, {
       method: 'GET',
       signal,
-      next: { revalidate: 60 }, // 1分ごとに再検証
+      cache: 'no-store',
     });
     const result: Task[] = (await res.json()) as Task[];
     return result;
@@ -20,7 +20,7 @@ export const getNGTasks = async (signal?: AbortSignal): Promise<Task[]> => {
     const res = await fetch(`/api/tasks/ng`, {
       method: 'GET',
       signal,
-      next: { revalidate: 60 }, // 1分ごとに再検証
+      cache: 'no-store',
     });
     const result: Task[] = (await res.json()) as Task[];
     return result;

--- a/src/util/hooks/useTaskListData.ts
+++ b/src/util/hooks/useTaskListData.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { AccountData, Task } from '@/src/types';
+import { getMemberAssignTask } from '@/src/util/actions/get-member-tasks';
+import { getAllTasks, getNGTasks } from '@/src/util/actions/get-tasks';
+
+type DataType = 'active' | 'NG';
+
+type Params = {
+  account: AccountData;
+  id: number;
+  initialType?: DataType;
+};
+
+export const useTaskListData = ({ account, id, initialType = 'active' }: Params) => {
+  const requestIdRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const [data, setData] = useState<Task[]>([]);
+  const [dataType, setDataType] = useState<DataType>(initialType);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTasks = useCallback(
+    async (targetType: DataType) => {
+      const controller = new AbortController();
+      if (abortRef.current) {
+        abortRef.current.abort();
+      }
+      abortRef.current = controller;
+
+      const currentRequestId = requestIdRef.current + 1;
+      requestIdRef.current = currentRequestId;
+
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const result =
+          targetType === 'NG'
+            ? await getNGTasks(controller.signal)
+            : account.role === 'member'
+              ? await getMemberAssignTask(String(id), controller.signal)
+              : await getAllTasks(controller.signal);
+
+        if (requestIdRef.current !== currentRequestId) {
+          return;
+        }
+        setData(result);
+        setDataType(targetType);
+      } catch (err) {
+        if (requestIdRef.current !== currentRequestId) {
+          return;
+        }
+        if (err instanceof DOMException && err.name === 'AbortError') {
+          return;
+        }
+        console.error('Failed to fetch task data:', err);
+        setError('タスクの取得に失敗しました');
+        setData([]);
+      } finally {
+        if (requestIdRef.current === currentRequestId) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [account.role, id],
+  );
+
+  const changeDataType = useCallback(
+    (nextType: DataType) => {
+      if (nextType === dataType) return;
+      fetchTasks(nextType)
+        .then()
+        .catch((e) => console.error(e));
+    },
+    [dataType, fetchTasks],
+  );
+
+  const reloadCurrent = useCallback(() => {
+    fetchTasks(dataType)
+      .then()
+      .catch((e) => console.error(e));
+  }, [dataType, fetchTasks]);
+
+  useEffect(() => {
+    fetchTasks(initialType)
+      .then()
+      .catch((e) => console.error(e));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchTasks, initialType, account.role, id]);
+
+  return {
+    data,
+    dataType,
+    isLoading,
+    error,
+    changeDataType,
+    reloadCurrent,
+  };
+};

--- a/src/util/hooks/useTaskListData.ts
+++ b/src/util/hooks/useTaskListData.ts
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
+import useSWR from 'swr';
 
 import { AccountData, Task } from '@/src/types';
-import { getMemberAssignTask } from '@/src/util/actions/get-member-tasks';
-import { getAllTasks, getNGTasks } from '@/src/util/actions/get-tasks';
+import { fetcher } from '@/src/util/swr/fetcher';
+import { SWR_KEYS } from '@/src/util/swr/keys';
 
 type DataType = 'active' | 'NG';
 
@@ -12,90 +13,45 @@ type Params = {
   initialType?: DataType;
 };
 
-export const useTaskListData = ({ account, id, initialType = 'active' }: Params) => {
-  const requestIdRef = useRef(0);
-  const abortRef = useRef<AbortController | null>(null);
-
-  const [data, setData] = useState<Task[]>([]);
+export const useTaskListData = ({
+  account,
+  id,
+  initialType = 'active',
+}: Params) => {
   const [dataType, setDataType] = useState<DataType>(initialType);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
 
-  const fetchTasks = useCallback(
-    async (targetType: DataType) => {
-      const controller = new AbortController();
-      if (abortRef.current) {
-        abortRef.current.abort();
-      }
-      abortRef.current = controller;
+  const swrKey =
+    dataType === 'NG'
+      ? SWR_KEYS.ngTasks
+      : account.role === 'member'
+        ? SWR_KEYS.memberTasks(String(id))
+        : SWR_KEYS.allTasks;
 
-      const currentRequestId = requestIdRef.current + 1;
-      requestIdRef.current = currentRequestId;
+  const {
+    data = [],
+    error,
+    isLoading,
+    mutate: boundMutate,
+  } = useSWR<Task[], Error>(swrKey, fetcher, {
+    revalidateOnFocus: false,
+    dedupingInterval: 2000,
+  });
 
-      setIsLoading(true);
-      setError(null);
-
-      try {
-        const result =
-          targetType === 'NG'
-            ? await getNGTasks(controller.signal)
-            : account.role === 'member'
-              ? await getMemberAssignTask(String(id), controller.signal)
-              : await getAllTasks(controller.signal);
-
-        if (requestIdRef.current !== currentRequestId) {
-          return;
-        }
-        setData(result);
-        setDataType(targetType);
-      } catch (err) {
-        if (requestIdRef.current !== currentRequestId) {
-          return;
-        }
-        if (err instanceof DOMException && err.name === 'AbortError') {
-          return;
-        }
-        console.error('Failed to fetch task data:', err);
-        setError('タスクの取得に失敗しました');
-        setData([]);
-      } finally {
-        if (requestIdRef.current === currentRequestId) {
-          setIsLoading(false);
-        }
-      }
-    },
-    [account.role, id],
-  );
-
-  const changeDataType = useCallback(
-    (nextType: DataType) => {
-      if (nextType === dataType) return;
-      fetchTasks(nextType)
-        .then()
-        .catch((e) => console.error(e));
-    },
-    [dataType, fetchTasks],
-  );
+  const changeDataType = useCallback((nextType: DataType) => {
+    setDataType(nextType);
+  }, []);
 
   const reloadCurrent = useCallback(() => {
-    fetchTasks(dataType)
-      .then()
-      .catch((e) => console.error(e));
-  }, [dataType, fetchTasks]);
-
-  useEffect(() => {
-    fetchTasks(initialType)
-      .then()
-      .catch((e) => console.error(e));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchTasks, initialType, account.role, id]);
+    void boundMutate();
+  }, [boundMutate]);
 
   return {
     data,
     dataType,
     isLoading,
-    error,
+    error: error ? 'タスクの取得に失敗しました' : null,
     changeDataType,
     reloadCurrent,
+    mutate: boundMutate,
   };
 };

--- a/src/util/swr/fetcher.ts
+++ b/src/util/swr/fetcher.ts
@@ -1,0 +1,7 @@
+export const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Failed to fetch');
+  }
+  return res.json();
+};

--- a/src/util/swr/keys.ts
+++ b/src/util/swr/keys.ts
@@ -1,0 +1,5 @@
+export const SWR_KEYS = {
+  memberTasks: (accountId: string) => `/api/account/${accountId}/tasks`,
+  allTasks: '/api/tasks/all?type=all',
+  ngTasks: '/api/tasks/ng',
+} as const;


### PR DESCRIPTION
@codex review
  ## 概要

  - TaskList周辺のデータ取得を安定化し、連打時に最新レスポンスのみ採用されるようにしました。
  - 取得ロジックをhook化し、ローディング/エラーを局所管理。AbortControllerとrequestIdで競合を防止。
  - 開発者向けガイド AGENTS.md を追加（既存コミット含む）。

  ## 変更理由

  - onChangeDataType連打で古いレスポンスが反映されるリスクがあり、画面点滅・不要再描画が発生していたため。
  - ローディング/エラーが画面全体に波及しUXを損ねていたため、取得責務を分離し、状態を局所化する必要があったため。
  - タスク取得処理の再利用性とテスト容易性を高めることで、今後の拡張や不具合調査を容易にするため。

  ## 変更内容

  - TaskList: 取得処理を useTaskListData に委譲し、requestId+Abortで最新のみ反映。ローディング/エラー表示を局所化。
  - useTaskListData（新規）: データ取得と状態管理を一元化、type切替/再取得を提供。
  - fetchアクション: getAllTasks / getNGTasks / getMemberAssignTask に signal 引数を追加しAbort伝播。
  - テスト: TaskListテストをAbortSignal対応に合わせて更新。
  - ドキュメント: AGENTS.md 追加。

  ## 動作確認

  - npm run lint -- --no-cache : Pass
  - npm test : Pass (13/13 suites, 56 tests)
  - 手動: onChangeDataType 連打で最新レスポンスのみ反映され、ローディング/エラーがTaskList内に閉じることを確認。

  ## 影響範囲とリスク

  - TaskListの取得経路・state管理が変更。親/子へのpropsは同一インターフェースを維持。