### PR TITLE
refactor: FP境界分離アーキテクチャ Phase 1-2 実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# dev end file
+.env*.development

--- a/src/__tests__/components/Details/AdminDetail.test.tsx
+++ b/src/__tests__/components/Details/AdminDetail.test.tsx
@@ -22,6 +22,18 @@ jest.mock('@/src/components/LoadCircle', () => {
   };
 });
 
+// useTaskMutationのモック
+const mockReassign = jest.fn().mockResolvedValue({ success: true });
+
+jest.mock('@/src/mutations', () => ({
+  useTaskMutation: () => ({
+    completeTask: jest.fn(),
+    markAsNG: jest.fn(),
+    reassign: mockReassign,
+    isPending: jest.fn().mockReturnValue(false),
+  }),
+}));
+
 describe('AdminDetail', () => {
   // mutateモック: 第一引数が関数の場合は実行してfetch呼び出しをトリガー
   const mockMutate = jest.fn(async (fn) => {
@@ -47,6 +59,7 @@ describe('AdminDetail', () => {
 
   beforeEach(() => {
     mockMutate.mockClear();
+    mockReassign.mockClear();
   });
 
   it('renders correctly when loaded', () => {
@@ -75,37 +88,14 @@ describe('AdminDetail', () => {
     expect(screen.queryByText('再アサイン')).not.toBeInTheDocument();
   });
 
-  it('calls mutate function when reassign button is clicked', async () => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({}),
-        text: () => Promise.resolve(''),
-        blob: () => Promise.resolve(new Blob()),
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-        formData: () => Promise.resolve(new FormData()),
-        headers: new Headers(),
-        redirected: false,
-        status: 200,
-        statusText: 'OK',
-        type: 'default' as ResponseType,
-        url: 'https://example.com',
-        clone: function () {
-          return Promise.resolve(this);
-        },
-      } as unknown as Response),
-    );
-
+  it('calls reassign when reassign button is clicked', async () => {
     render(<AdminDetail {...mockProps} dataType="NG" />);
 
     const reassignButton = screen.getByText('再アサイン');
     fireEvent.click(reassignButton);
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith('/api/task/123/reassign', {
-        method: 'PUT',
-      });
-      expect(mockMutate).toHaveBeenCalled();
+      expect(mockReassign).toHaveBeenCalledWith(123, '123');
     });
   });
 });

--- a/src/__tests__/components/Details/MemberDetail.test.tsx
+++ b/src/__tests__/components/Details/MemberDetail.test.tsx
@@ -24,21 +24,21 @@ jest.mock('@/src/components/LoadCircle', () => {
   };
 });
 
-// フェッチのモック
-global.fetch = jest.fn(() =>
-  Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve({}),
+// useTaskMutationのモック
+const mockCompleteTask = jest.fn().mockResolvedValue({ success: true });
+const mockMarkAsNG = jest.fn().mockResolvedValue({ success: true });
+
+jest.mock('@/src/mutations', () => ({
+  useTaskMutation: () => ({
+    completeTask: mockCompleteTask,
+    markAsNG: mockMarkAsNG,
+    reassign: jest.fn(),
+    isPending: jest.fn().mockReturnValue(false),
   }),
-) as jest.Mock;
+}));
 
 describe('MemberDetail', () => {
-  // mutateモック: 第一引数が関数の場合は実行してfetch呼び出しをトリガー
-  const mockMutate = jest.fn(async (fn) => {
-    if (typeof fn === 'function') {
-      await fn([]);
-    }
-  });
+  const mockMutate = jest.fn();
 
   const mockProps = {
     account: {
@@ -61,7 +61,8 @@ describe('MemberDetail', () => {
 
   beforeEach(() => {
     mockMutate.mockClear();
-    (global.fetch as jest.Mock).mockClear();
+    mockCompleteTask.mockClear();
+    mockMarkAsNG.mockClear();
   });
 
   it('renders correctly when loaded', () => {
@@ -80,29 +81,23 @@ describe('MemberDetail', () => {
     expect(screen.getByTestId('load-circle')).toBeInTheDocument();
   });
 
-  it('calls changeComplete when 完了 button is clicked', async () => {
+  it('calls completeTask when 完了 button is clicked', async () => {
     render(<MemberDetail {...mockProps} />);
 
     fireEvent.click(screen.getByText('完了'));
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith('/api/task/1/complete', {
-        method: 'PUT',
-      });
-      expect(mockMutate).toHaveBeenCalled();
+      expect(mockCompleteTask).toHaveBeenCalledWith(1, '1');
     });
   });
 
-  it('calls changeNG when NG button is clicked', async () => {
+  it('calls markAsNG when NG button is clicked', async () => {
     render(<MemberDetail {...mockProps} />);
 
     fireEvent.click(screen.getByText('NG'));
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith('/api/task/1/ng', {
-        method: 'PUT',
-      });
-      expect(mockMutate).toHaveBeenCalled();
+      expect(mockMarkAsNG).toHaveBeenCalledWith(1, '1');
     });
   });
 });

--- a/src/__tests__/components/TaskList.test.tsx
+++ b/src/__tests__/components/TaskList.test.tsx
@@ -4,13 +4,13 @@ import '@testing-library/jest-dom';
 import TaskList from '@/src/components/TaskList';
 import { AccountData, Task } from '@/src/types';
 
-// useTaskListDataをモック
+// useTaskListをモック
 const mockMutate = jest.fn();
 const mockChangeDataType = jest.fn();
-const mockUseTaskListData = jest.fn();
+const mockUseTaskList = jest.fn();
 
-jest.mock('@/src/util/hooks/useTaskListData', () => ({
-  useTaskListData: (params: unknown) => mockUseTaskListData(params),
+jest.mock('@/src/queries', () => ({
+  useTaskList: (params: unknown) => mockUseTaskList(params),
 }));
 
 // TaskAccordionをモック
@@ -66,11 +66,11 @@ describe('TaskList', () => {
   beforeEach(() => {
     mockMutate.mockClear();
     mockChangeDataType.mockClear();
-    mockUseTaskListData.mockClear();
+    mockUseTaskList.mockClear();
   });
 
   test('renders TaskList for member and fetches member tasks', async () => {
-    mockUseTaskListData.mockReturnValue({
+    mockUseTaskList.mockReturnValue({
       data: mockTasks,
       dataType: 'active',
       isLoading: false,
@@ -82,7 +82,7 @@ describe('TaskList', () => {
     render(<TaskList id={1} account={mockMemberAccount} />);
 
     await waitFor(() => {
-      expect(mockUseTaskListData).toHaveBeenCalledWith({
+      expect(mockUseTaskList).toHaveBeenCalledWith({
         account: mockMemberAccount,
         id: 1,
       });
@@ -90,7 +90,7 @@ describe('TaskList', () => {
   });
 
   test('renders TaskList for admin and fetches all tasks', async () => {
-    mockUseTaskListData.mockReturnValue({
+    mockUseTaskList.mockReturnValue({
       data: mockTasks,
       dataType: 'active',
       isLoading: false,
@@ -102,7 +102,7 @@ describe('TaskList', () => {
     render(<TaskList id={2} account={mockAdminAccount} />);
 
     await waitFor(() => {
-      expect(mockUseTaskListData).toHaveBeenCalledWith({
+      expect(mockUseTaskList).toHaveBeenCalledWith({
         account: mockAdminAccount,
         id: 2,
       });
@@ -110,7 +110,7 @@ describe('TaskList', () => {
   });
 
   test('displays loading indicator when loading', async () => {
-    mockUseTaskListData.mockReturnValue({
+    mockUseTaskList.mockReturnValue({
       data: [],
       dataType: 'active',
       isLoading: true,
@@ -125,7 +125,7 @@ describe('TaskList', () => {
   });
 
   test('handles fetch error gracefully', async () => {
-    mockUseTaskListData.mockReturnValue({
+    mockUseTaskList.mockReturnValue({
       data: [],
       dataType: 'active',
       isLoading: false,
@@ -142,7 +142,7 @@ describe('TaskList', () => {
   });
 
   test('displays tasks after loading', async () => {
-    mockUseTaskListData.mockReturnValue({
+    mockUseTaskList.mockReturnValue({
       data: mockTasks,
       dataType: 'active',
       isLoading: false,
@@ -160,7 +160,7 @@ describe('TaskList', () => {
   });
 
   test('admin can see NG button group', async () => {
-    mockUseTaskListData.mockReturnValue({
+    mockUseTaskList.mockReturnValue({
       data: mockTasks,
       dataType: 'active',
       isLoading: false,
@@ -177,7 +177,7 @@ describe('TaskList', () => {
   });
 
   test('member cannot see NG button group', async () => {
-    mockUseTaskListData.mockReturnValue({
+    mockUseTaskList.mockReturnValue({
       data: mockTasks,
       dataType: 'active',
       isLoading: false,
@@ -189,14 +189,14 @@ describe('TaskList', () => {
     render(<TaskList id={1} account={mockMemberAccount} />);
 
     await waitFor(() => {
-      expect(mockUseTaskListData).toHaveBeenCalled();
+      expect(mockUseTaskList).toHaveBeenCalled();
     });
 
     expect(screen.queryByRole('button', { name: 'NG' })).not.toBeInTheDocument();
   });
 
   test('switches sort type', async () => {
-    mockUseTaskListData.mockReturnValue({
+    mockUseTaskList.mockReturnValue({
       data: mockTasks,
       dataType: 'active',
       isLoading: false,

--- a/src/api/tasks/fetchers.ts
+++ b/src/api/tasks/fetchers.ts
@@ -1,0 +1,38 @@
+import { DomainError, toDisplayError } from '@/src/domain/types/error';
+import { httpClient } from '@/src/infra/http';
+import { Task } from '@/src/types';
+
+/**
+ * SWR用カスタムエラークラス
+ * SWRはErrorインスタンスを期待するため、DomainErrorをラップ
+ */
+export class TaskFetchError extends Error {
+  public readonly domainError: DomainError;
+
+  constructor(domainError: DomainError) {
+    super(toDisplayError(domainError));
+    this.name = 'TaskFetchError';
+    this.domainError = domainError;
+  }
+}
+
+/**
+ * タスク一覧取得用fetcher
+ * SWRで使用するためError throwパターン
+ */
+export const taskListFetcher = async (url: string): Promise<Task[]> => {
+  const result = await httpClient.get<Task[]>(url);
+
+  if (!result.ok) {
+    throw new TaskFetchError(result.error);
+  }
+
+  return result.value;
+};
+
+/**
+ * エラーがTaskFetchErrorかどうかを判定
+ */
+export const isTaskFetchError = (error: unknown): error is TaskFetchError => {
+  return error instanceof TaskFetchError;
+};

--- a/src/api/tasks/index.ts
+++ b/src/api/tasks/index.ts
@@ -1,0 +1,1 @@
+export { taskListFetcher, TaskFetchError, isTaskFetchError } from './fetchers';

--- a/src/components/Details/AdminDetail.tsx
+++ b/src/components/Details/AdminDetail.tsx
@@ -5,6 +5,7 @@ import { KeyedMutator } from 'swr';
 import { BasicButton } from '@/src/components/Buttons/BasicButton';
 import CommentList from '@/src/components/CommentList';
 import LoadCircle from '@/src/components/LoadCircle';
+import { useTaskMutation } from '@/src/mutations';
 import { AccountData, Comment, Task } from '@/src/types';
 
 type Props = {
@@ -22,26 +23,10 @@ type Props = {
 };
 
 const AdminDetail = (props: Props) => {
-  const putReassign = async () => {
-    await props.mutate(
-      async (currentData) => {
-        const res = await fetch(`/api/task/${String(props.id)}/reassign`, {
-          method: 'PUT',
-        });
-        if (!res.ok) throw new Error('Failed to reassign');
-        return currentData?.filter((task) => task.id !== props.taskId);
-      },
-      {
-        optimisticData: (currentData) =>
-          currentData?.filter((task) => task.id !== props.taskId),
-        rollbackOnError: true,
-        revalidate: false,
-      },
-    );
-  };
+  const { reassign } = useTaskMutation(props.mutate);
 
   const onReassign = (): void => {
-    putReassign().catch((e) => console.error(e));
+    reassign(props.taskId, props.id).catch((e) => console.error(e));
   };
   return (
     <AccordionDetails>

--- a/src/components/Details/MemberDetail.tsx
+++ b/src/components/Details/MemberDetail.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/src/components/Buttons/BasicButton';
 import CommentList from '@/src/components/CommentList';
 import LoadCircle from '@/src/components/LoadCircle';
+import { useTaskMutation } from '@/src/mutations';
 import { AccountData, Comment, Task } from '@/src/types';
 
 type Props = {
@@ -24,48 +25,14 @@ type Props = {
 };
 
 const MemberDetail = (props: Props) => {
-  const changeNG = async () => {
-    await props.mutate(
-      async (currentData) => {
-        const res = await fetch(`/api/task/${String(props.id)}/ng`, {
-          method: 'PUT',
-        });
-        if (!res.ok) throw new Error('Failed to mark as NG');
-        return currentData?.filter((task) => task.id !== props.taskId);
-      },
-      {
-        optimisticData: (currentData) =>
-          currentData?.filter((task) => task.id !== props.taskId),
-        rollbackOnError: true,
-        revalidate: false,
-      },
-    );
-  };
-
-  const changeComplete = async () => {
-    await props.mutate(
-      async (currentData) => {
-        const res = await fetch(`/api/task/${String(props.id)}/complete`, {
-          method: 'PUT',
-        });
-        if (!res.ok) throw new Error('Failed to mark as complete');
-        return currentData?.filter((task) => task.id !== props.taskId);
-      },
-      {
-        optimisticData: (currentData) =>
-          currentData?.filter((task) => task.id !== props.taskId),
-        rollbackOnError: true,
-        revalidate: false,
-      },
-    );
-  };
+  const { completeTask, markAsNG } = useTaskMutation(props.mutate);
 
   const onNG = (): void => {
-    changeNG().catch((e) => console.error(e));
+    markAsNG(props.taskId, props.id).catch((e) => console.error(e));
   };
 
   const onComplete = (): void => {
-    changeComplete().catch((e) => console.error(e));
+    completeTask(props.taskId, props.id).catch((e) => console.error(e));
   };
 
   return (

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -13,10 +13,10 @@ import { useCallback, useMemo, useState } from 'react';
 
 import LoadCircle from '@/src/components/LoadCircle';
 import TaskAccordion from '@/src/components/TaskAccordion';
+import { useTaskList } from '@/src/queries';
 import { AccountData } from '@/src/types';
 import { Task } from '@/src/types';
 import { grouping } from '@/src/util/grouping';
-import { useTaskListData } from '@/src/util/hooks/useTaskListData';
 
 type Props = {
   id: number;
@@ -36,7 +36,7 @@ const sortTasks = (list: string[], sortType: string) => {
 const TaskList = (props: Props) => {
   const [sortType, setSortType] = useState<string>('time');
   const { data, dataType, isLoading, error, changeDataType, mutate } =
-    useTaskListData({ account: props.account, id: props.id });
+    useTaskList({ account: props.account, id: props.id });
 
   const onChangeType = useCallback((type: string) => {
     setSortType(type);

--- a/src/domain/types/error.ts
+++ b/src/domain/types/error.ts
@@ -1,0 +1,88 @@
+/**
+ * API エラー型
+ * HTTPリクエストが失敗した場合（4xx, 5xx）
+ */
+export type ApiError = {
+  type: 'api';
+  status: number;
+  message: string;
+  details?: Record<string, unknown>;
+};
+
+/**
+ * ネットワークエラー型
+ * ネットワーク接続エラー、タイムアウト等
+ */
+export type NetworkError = {
+  type: 'network';
+  message: string;
+};
+
+/**
+ * ドメインエラー型（統一エラー型）
+ */
+export type DomainError = ApiError | NetworkError;
+
+/**
+ * Result型
+ * 成功/失敗を明示的に表現する型
+ */
+export type Result<T, E = DomainError> =
+  | { ok: true; value: T }
+  | { ok: false; error: E };
+
+/**
+ * Result型のヘルパー関数
+ */
+export const ok = <T>(value: T): Result<T, never> => ({
+  ok: true,
+  value,
+});
+
+export const err = <E>(error: E): Result<never, E> => ({
+  ok: false,
+  error,
+});
+
+/**
+ * ApiErrorを生成するヘルパー
+ */
+export const createApiError = (
+  status: number,
+  message: string,
+  details?: Record<string, unknown>,
+): ApiError => ({
+  type: 'api',
+  status,
+  message,
+  details,
+});
+
+/**
+ * NetworkErrorを生成するヘルパー
+ */
+export const createNetworkError = (message: string): NetworkError => ({
+  type: 'network',
+  message,
+});
+
+/**
+ * DomainErrorかどうかを判定する型ガード
+ */
+export const isDomainError = (error: unknown): error is DomainError => {
+  if (typeof error !== 'object' || error === null) return false;
+  const e = error as Record<string, unknown>;
+  return e.type === 'api' || e.type === 'network';
+};
+
+/**
+ * エラーを表示用文字列に変換
+ */
+export const toDisplayError = (error: DomainError): string => {
+  switch (error.type) {
+    case 'api':
+      return `エラー (${String(error.status)}): ${error.message}`;
+    case 'network':
+      return `ネットワークエラー: ${error.message}`;
+  }
+};

--- a/src/domain/types/index.ts
+++ b/src/domain/types/index.ts
@@ -1,0 +1,1 @@
+export * from './error';

--- a/src/infra/http/client.ts
+++ b/src/infra/http/client.ts
@@ -1,0 +1,164 @@
+import {
+  Result,
+  ok,
+  err,
+  createApiError,
+  createNetworkError,
+} from '@/src/domain/types/error';
+
+type RequestOptions = {
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+};
+
+/**
+ * HTTPクライアント
+ * 全てのHTTPリクエストをResult型で返す
+ */
+export const httpClient = {
+  /**
+   * GETリクエスト
+   */
+  get: async <T>(url: string, options?: RequestOptions): Promise<Result<T>> => {
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+        signal: options?.signal,
+        headers: options?.headers,
+      });
+
+      if (!res.ok) {
+        const message = await res.text().catch(() => 'Unknown error');
+        return err(createApiError(res.status, message));
+      }
+
+      const data = (await res.json()) as T;
+      return ok(data);
+    } catch (e) {
+      // AbortErrorは再throwして呼び出し側でハンドリング
+      if (e instanceof Error && e.name === 'AbortError') {
+        throw e;
+      }
+      return err(createNetworkError(String(e)));
+    }
+  },
+
+  /**
+   * POSTリクエスト
+   */
+  post: async <T>(
+    url: string,
+    body?: unknown,
+    options?: RequestOptions,
+  ): Promise<Result<T>> => {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        signal: options?.signal,
+        headers: {
+          'Content-Type': 'application/json',
+          ...options?.headers,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      if (!res.ok) {
+        const message = await res.text().catch(() => 'Unknown error');
+        return err(createApiError(res.status, message));
+      }
+
+      const data = (await res.json()) as T;
+      return ok(data);
+    } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') {
+        throw e;
+      }
+      return err(createNetworkError(String(e)));
+    }
+  },
+
+  /**
+   * PUTリクエスト
+   */
+  put: async <T>(
+    url: string,
+    body?: unknown,
+    options?: RequestOptions,
+  ): Promise<Result<T>> => {
+    try {
+      const res = await fetch(url, {
+        method: 'PUT',
+        signal: options?.signal,
+        headers: body
+          ? {
+              'Content-Type': 'application/json',
+              ...options?.headers,
+            }
+          : options?.headers,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+
+      if (!res.ok) {
+        const message = await res.text().catch(() => 'Unknown error');
+        return err(createApiError(res.status, message));
+      }
+
+      // PUTは空レスポンスの場合がある
+      const text = await res.text();
+      if (!text) {
+        return ok({} as T);
+      }
+
+      try {
+        const data = JSON.parse(text) as T;
+        return ok(data);
+      } catch {
+        return ok({} as T);
+      }
+    } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') {
+        throw e;
+      }
+      return err(createNetworkError(String(e)));
+    }
+  },
+
+  /**
+   * DELETEリクエスト
+   */
+  delete: async <T>(
+    url: string,
+    options?: RequestOptions,
+  ): Promise<Result<T>> => {
+    try {
+      const res = await fetch(url, {
+        method: 'DELETE',
+        signal: options?.signal,
+        headers: options?.headers,
+      });
+
+      if (!res.ok) {
+        const message = await res.text().catch(() => 'Unknown error');
+        return err(createApiError(res.status, message));
+      }
+
+      // DELETEは空レスポンスの場合がある
+      const text = await res.text();
+      if (!text) {
+        return ok({} as T);
+      }
+
+      try {
+        const data = JSON.parse(text) as T;
+        return ok(data);
+      } catch {
+        return ok({} as T);
+      }
+    } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') {
+        throw e;
+      }
+      return err(createNetworkError(String(e)));
+    }
+  },
+};

--- a/src/infra/http/index.ts
+++ b/src/infra/http/index.ts
@@ -1,0 +1,1 @@
+export { httpClient } from './client';

--- a/src/mutations/index.ts
+++ b/src/mutations/index.ts
@@ -1,0 +1,1 @@
+export { useTaskMutation } from './useTaskMutation';

--- a/src/mutations/useTaskMutation.ts
+++ b/src/mutations/useTaskMutation.ts
@@ -1,0 +1,154 @@
+import { useCallback, useRef } from 'react';
+import { KeyedMutator } from 'swr';
+
+import { httpClient } from '@/src/infra/http';
+import { Task } from '@/src/types';
+
+type MutationResult = {
+  success: boolean;
+  error?: string;
+};
+
+/**
+ * タスク更新用Mutation Hook
+ *
+ * 機能:
+ * - 楽観的更新（Optimistic Update）
+ * - 連打防止（同一タスクへの重複リクエスト防止）
+ * - エラー時の自動ロールバック
+ */
+export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
+  // 処理中のタスクIDを追跡（連打防止）
+  const pendingTasksRef = useRef<Set<number>>(new Set());
+
+  /**
+   * タスクを完了状態にする
+   */
+  const completeTask = useCallback(
+    async (taskId: number, historyId: string): Promise<MutationResult> => {
+      // 連打防止: 既に処理中なら何もしない
+      if (pendingTasksRef.current.has(taskId)) {
+        return { success: false, error: '処理中です' };
+      }
+      pendingTasksRef.current.add(taskId);
+
+      try {
+        await mutate(
+          async (currentData) => {
+            const result = await httpClient.put(
+              `/api/task/${historyId}/complete`,
+            );
+            if (!result.ok) {
+              throw new Error(result.error.message);
+            }
+            return currentData?.filter((t) => t.id !== taskId);
+          },
+          {
+            optimisticData: (currentData) =>
+              currentData?.filter((t) => t.id !== taskId),
+            rollbackOnError: true,
+            revalidate: false,
+          },
+        );
+        return { success: true };
+      } catch (e) {
+        const message = e instanceof Error ? e.message : '完了処理に失敗しました';
+        return { success: false, error: message };
+      } finally {
+        pendingTasksRef.current.delete(taskId);
+      }
+    },
+    [mutate],
+  );
+
+  /**
+   * タスクをNG状態にする
+   */
+  const markAsNG = useCallback(
+    async (taskId: number, historyId: string): Promise<MutationResult> => {
+      if (pendingTasksRef.current.has(taskId)) {
+        return { success: false, error: '処理中です' };
+      }
+      pendingTasksRef.current.add(taskId);
+
+      try {
+        await mutate(
+          async (currentData) => {
+            const result = await httpClient.put(`/api/task/${historyId}/ng`);
+            if (!result.ok) {
+              throw new Error(result.error.message);
+            }
+            return currentData?.filter((t) => t.id !== taskId);
+          },
+          {
+            optimisticData: (currentData) =>
+              currentData?.filter((t) => t.id !== taskId),
+            rollbackOnError: true,
+            revalidate: false,
+          },
+        );
+        return { success: true };
+      } catch (e) {
+        const message = e instanceof Error ? e.message : 'NG処理に失敗しました';
+        return { success: false, error: message };
+      } finally {
+        pendingTasksRef.current.delete(taskId);
+      }
+    },
+    [mutate],
+  );
+
+  /**
+   * タスクを再アサインする
+   */
+  const reassign = useCallback(
+    async (taskId: number, taskIdStr: string): Promise<MutationResult> => {
+      if (pendingTasksRef.current.has(taskId)) {
+        return { success: false, error: '処理中です' };
+      }
+      pendingTasksRef.current.add(taskId);
+
+      try {
+        await mutate(
+          async (currentData) => {
+            const result = await httpClient.put(
+              `/api/task/${taskIdStr}/reassign`,
+            );
+            if (!result.ok) {
+              throw new Error(result.error.message);
+            }
+            return currentData?.filter((t) => t.id !== taskId);
+          },
+          {
+            optimisticData: (currentData) =>
+              currentData?.filter((t) => t.id !== taskId),
+            rollbackOnError: true,
+            revalidate: false,
+          },
+        );
+        return { success: true };
+      } catch (e) {
+        const message =
+          e instanceof Error ? e.message : '再アサイン処理に失敗しました';
+        return { success: false, error: message };
+      } finally {
+        pendingTasksRef.current.delete(taskId);
+      }
+    },
+    [mutate],
+  );
+
+  /**
+   * タスクが処理中かどうかを確認
+   */
+  const isPending = useCallback((taskId: number): boolean => {
+    return pendingTasksRef.current.has(taskId);
+  }, []);
+
+  return {
+    completeTask,
+    markAsNG,
+    reassign,
+    isPending,
+  };
+};

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,0 +1,1 @@
+export { useTaskList } from './useTaskList';

--- a/src/queries/useTaskList.ts
+++ b/src/queries/useTaskList.ts
@@ -1,0 +1,88 @@
+import { useCallback, useState } from 'react';
+import useSWR from 'swr';
+
+import {
+  taskListFetcher,
+  TaskFetchError,
+  isTaskFetchError,
+} from '@/src/api/tasks';
+import { toDisplayError } from '@/src/domain/types/error';
+import { AccountData, Task } from '@/src/types';
+import { SWR_KEYS } from '@/src/util/swr/keys';
+
+type DataType = 'active' | 'NG';
+
+type Params = {
+  account: AccountData;
+  id: number;
+  initialType?: DataType;
+};
+
+type UseTaskListReturn = {
+  data: Task[];
+  dataType: DataType;
+  isLoading: boolean;
+  error: string | null;
+  changeDataType: (nextType: DataType) => void;
+  reloadCurrent: () => void;
+  mutate: ReturnType<typeof useSWR<Task[], TaskFetchError>>['mutate'];
+};
+
+/**
+ * タスク一覧を取得するSWR Query Hook
+ *
+ * 改善点:
+ * - TaskFetchErrorによる詳細なエラー情報
+ * - revalidateOnReconnect: false で意図しない再検証を防止
+ */
+export const useTaskList = ({
+  account,
+  id,
+  initialType = 'active',
+}: Params): UseTaskListReturn => {
+  const [dataType, setDataType] = useState<DataType>(initialType);
+
+  // dataTypeとroleに応じてSWRキーを決定
+  const swrKey =
+    dataType === 'NG'
+      ? SWR_KEYS.ngTasks
+      : account.role === 'member'
+        ? SWR_KEYS.memberTasks(String(id))
+        : SWR_KEYS.allTasks;
+
+  const {
+    data = [],
+    error,
+    isLoading,
+    mutate: boundMutate,
+  } = useSWR<Task[], TaskFetchError>(swrKey, taskListFetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false, // 意図しない再検証を防止
+    dedupingInterval: 2000,
+  });
+
+  const changeDataType = useCallback((nextType: DataType) => {
+    setDataType(nextType);
+  }, []);
+
+  const reloadCurrent = useCallback(() => {
+    void boundMutate();
+  }, [boundMutate]);
+
+  // エラーメッセージの生成
+  const errorMessage = error
+    ? isTaskFetchError(error)
+      ? toDisplayError(error.domainError)
+      : 'タスクの取得に失敗しました'
+    : null;
+
+  return {
+    data,
+    dataType,
+    isLoading,
+    error: errorMessage,
+    changeDataType,
+    reloadCurrent,
+    mutate: boundMutate,
+  };
+};


### PR DESCRIPTION
変更内容:
- Result型とドメインエラー型定義 (src/domain/types/error.ts)
- HTTPクライアント統一 (src/infra/http/client.ts)
- SWR fetcher改良 (src/api/tasks/fetchers.ts)
- useTaskList hook作成 (src/queries/useTaskList.ts)
- useTaskMutation hook作成 (src/mutations/useTaskMutation.ts)
- MemberDetail/AdminDetailからfetch直書き削除
- テストファイルの更新

変更理由:
- 副作用をinfra層に隔離しテスト容易性向上
- UI層からfetch直書きを排除しSWR hooks経由に統一
- 連打防止（pendingRef）による競合抑止
- Result型によるエラー伝播の明示化

影響範囲:
- src/domain/types/ (新規)
- src/infra/http/ (新規)
- src/api/tasks/ (新規)
- src/queries/ (新規)
- src/mutations/ (新規)
- src/components/Details/MemberDetail.tsx
- src/components/Details/AdminDetail.tsx
- src/components/TaskList.tsx

テスト結果: Pass (56件)