### PR TITLE
refactor: useFileUploadをhttpClient化

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,89 @@
+# FP境界分離アーキテクチャ 残作業TODO
+
+## 優先度: 高
+
+### 1. Chart.tsx SWR Query化
+- [ ] `src/queries/useWeekComplete.ts` 作成
+- [ ] `src/api/get-week-complete.ts` をquery hookに置換
+- [ ] Chart.tsx の useEffect内fetch → useWeekComplete使用
+
+---
+
+## 優先度: 中
+
+### 2. Server Actions統一（src/api/*.ts）
+現在は直接fetchを使用、httpClient統一は任意
+- `get-account-status.ts`
+- `get-account-tasks.ts`
+- `get-account.ts`
+- `get-areas.ts`
+- `get-tasks.ts`
+- `get-unfulfilled-count.ts`
+- `get-week-complete.ts`
+- `post-login.ts`
+- `post-signup.ts`
+- `post-task-create.ts`
+
+---
+
+## 優先度: 低
+
+### 3. Phase 5: テスト整備
+- [ ] `src/domain/functions/date.ts` - 純粋関数テスト追加
+- [ ] `src/infra/http/client.ts` - httpClientテスト（MSW使用）
+- [ ] `src/queries/useTaskList.ts` - hookテスト
+- [ ] `src/queries/useTaskDetail.ts` - hookテスト
+- [ ] `src/mutations/useTaskMutation.ts` - hookテスト
+- [ ] `src/mutations/useCommentMutation.ts` - hookテスト
+- [ ] `src/mutations/useFileUpload.ts` - hookテスト
+
+### 4. エラー表示UI改善
+- [ ] トースト通知コンポーネント追加
+- [ ] mutation失敗時のユーザー通知
+- [ ] ネットワークエラー時のリトライUI
+
+---
+
+## 完了済み
+
+### Phase 1-2: 基盤整備
+- [x] `src/domain/types/error.ts` - Result型、DomainError
+- [x] `src/infra/http/client.ts` - 統一HTTPクライアント
+- [x] `src/api/tasks/fetchers.ts` - SWR fetcher
+- [x] `src/queries/useTaskList.ts` - タスク一覧query
+- [x] `src/mutations/useTaskMutation.ts` - タスクmutation
+
+### Phase 3: Date/Time純粋化
+- [x] `src/domain/functions/date.ts` - Date純粋関数
+- [x] `src/infra/time/index.ts` - Date I/O
+- [x] Copyright, Footer, Chart, grouping更新
+
+### Phase 4: 横展開
+- [x] `src/mutations/useCommentMutation.ts` - コメントmutation
+- [x] `src/queries/useTaskDetail.ts` - タスク詳細query
+- [x] `src/mutations/useFileUpload.ts` - ファイルアップロード（httpClient.postFormData使用）
+- [x] `src/mutations/useAccountMutation.ts` - アカウントmutation
+- [x] TaskAccordion, CommentList, UploadButton, MemberCard更新
+
+### クリーンアップ
+- [x] `src/util/fetch-comment.ts` 削除 - useCommentMutationに置換
+- [x] `src/util/hooks/useTaskListData.ts` 削除 - useTaskListに置換
+- [x] `src/util/swr/fetcher.ts` 削除 - taskListFetcherに置換
+- [x] `src/__tests__/components/CommentList.test.tsx` - モック更新
+- [x] `src/mutations/useFileUpload.ts` - httpClient.postFormData化
+
+---
+
+## アーキテクチャ図
+
+```
+UI (components, app)
+    ↓ (hooks経由)
+queries / mutations
+    ↓ (fetcher経由)
+api (adapters, fetchers)
+    ↓ (client経由)
+infra (http, time)
+
+domain ← 全層から参照可能（逆方向禁止）
+```

--- a/src/infra/http/client.ts
+++ b/src/infra/http/client.ts
@@ -161,4 +161,46 @@ export const httpClient = {
       return err(createNetworkError(String(e)));
     }
   },
+
+  /**
+   * FormDataをPOSTするリクエスト（ファイルアップロード用）
+   * Content-Typeはブラウザが自動設定（multipart/form-data + boundary）
+   */
+  postFormData: async <T>(
+    url: string,
+    formData: FormData,
+    options?: RequestOptions,
+  ): Promise<Result<T>> => {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        signal: options?.signal,
+        headers: options?.headers, // Content-Typeは設定しない
+        body: formData,
+      });
+
+      if (!res.ok) {
+        const message = await res.text().catch(() => 'Unknown error');
+        return err(createApiError(res.status, message));
+      }
+
+      // 空レスポンスの場合がある
+      const text = await res.text();
+      if (!text) {
+        return ok({} as T);
+      }
+
+      try {
+        const data = JSON.parse(text) as T;
+        return ok(data);
+      } catch {
+        return ok({} as T);
+      }
+    } catch (e) {
+      if (e instanceof Error && e.name === 'AbortError') {
+        throw e;
+      }
+      return err(createNetworkError(String(e)));
+    }
+  },
 };

--- a/src/mutations/useFileUpload.ts
+++ b/src/mutations/useFileUpload.ts
@@ -1,5 +1,7 @@
 import { useCallback, useState } from 'react';
 
+import { httpClient } from '@/src/infra/http';
+
 type UploadResult = {
   success: boolean;
   error?: string;
@@ -51,21 +53,12 @@ export const useFileUpload = () => {
           const formData = new FormData();
           formData.append('file', file);
 
-          const response = await fetch('/api/aws', {
-            method: 'POST',
-            body: formData,
-          });
+          const result = await httpClient.postFormData('/api/aws', formData);
 
-          if (!response.ok) {
-            const errorBody = (await response.json()) as unknown;
-            const errorMessage =
-              typeof errorBody === 'object' &&
-              errorBody !== null &&
-              'error' in errorBody &&
-              typeof (errorBody as { error?: unknown }).error === 'string'
-                ? (errorBody as { error?: string }).error
-                : 'Unknown error';
-            throw new Error(`Failed to upload ${file.name}: ${errorMessage}`);
+          if (!result.ok) {
+            throw new Error(
+              `Failed to upload ${file.name}: ${result.error.message}`,
+            );
           }
         }
 
@@ -91,7 +84,7 @@ export const useFileUpload = () => {
         return { success: false, error: message };
       }
     },
-    []
+    [],
   );
 
   return {


### PR DESCRIPTION
変更内容:
- httpClientにpostFormDataメソッドを追加（FormData対応）
- useFileUploadで直接fetchをhttpClient.postFormDataに置換
- TODO.mdを更新（完了タスクを反映）

変更理由:
- FP境界分離アーキテクチャに従い、HTTP通信をinfra層に統一
- Result型によるエラーハンドリングの統一

影響範囲:
- src/infra/http/client.ts
- src/mutations/useFileUpload.ts
- UploadButton.tsx（既にuseFileUpload使用）

テスト結果: Pass（56件）