### PR TITLE
refactor: Server Actions統一（serverHttpClient化）

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,26 +8,16 @@
 
 ## 優先度: 中
 
-### 1. Server Actions統一（src/api/*.ts）
-現在は直接fetchを使用、httpClient統一は任意
-- `get-account-status.ts`
-- `get-account-tasks.ts`
-- `get-account.ts`
-- `get-areas.ts`
-- `get-tasks.ts`
-- `get-unfulfilled-count.ts`
-- `get-week-complete.ts`
-- `post-login.ts`
-- `post-signup.ts`
-- `post-task-create.ts`
+（なし - Server Actions統一完了）
 
 ---
 
 ## 優先度: 低
 
-### 2. Phase 5: テスト整備
+### 1. Phase 5: テスト整備
 - [ ] `src/domain/functions/date.ts` - 純粋関数テスト追加
 - [ ] `src/infra/http/client.ts` - httpClientテスト（MSW使用）
+- [ ] `src/infra/http/serverClient.ts` - serverHttpClientテスト
 - [ ] `src/queries/useTaskList.ts` - hookテスト
 - [ ] `src/queries/useTaskDetail.ts` - hookテスト
 - [ ] `src/queries/useWeekComplete.ts` - hookテスト
@@ -35,7 +25,7 @@
 - [ ] `src/mutations/useCommentMutation.ts` - hookテスト
 - [ ] `src/mutations/useFileUpload.ts` - hookテスト
 
-### 3. エラー表示UI改善
+### 2. エラー表示UI改善
 - [ ] トースト通知コンポーネント追加
 - [ ] mutation失敗時のユーザー通知
 - [ ] ネットワークエラー時のリトライUI
@@ -46,7 +36,7 @@
 
 ### Phase 1-2: 基盤整備
 - [x] `src/domain/types/error.ts` - Result型、DomainError
-- [x] `src/infra/http/client.ts` - 統一HTTPクライアント
+- [x] `src/infra/http/client.ts` - 統一HTTPクライアント（クライアント用）
 - [x] `src/api/tasks/fetchers.ts` - SWR fetcher
 - [x] `src/queries/useTaskList.ts` - タスク一覧query
 - [x] `src/mutations/useTaskMutation.ts` - タスクmutation
@@ -64,6 +54,19 @@
 - [x] TaskAccordion, CommentList, UploadButton, MemberCard更新
 - [x] `src/queries/useWeekComplete.ts` - 週間完了データquery
 - [x] Chart.tsx SWR Query化（useEffect内fetch → useWeekComplete使用）
+
+### Server Actions統一
+- [x] `src/infra/http/serverClient.ts` - Server Actions用HTTPクライアント
+- [x] `get-account-status.ts` - serverHttpClient化
+- [x] `get-account-tasks.ts` - serverHttpClient化
+- [x] `get-account.ts` - serverHttpClient化
+- [x] `get-areas.ts` - serverHttpClient化
+- [x] `get-tasks.ts` - serverHttpClient化
+- [x] `get-unfulfilled-count.ts` - serverHttpClient化
+- [x] `get-week-complete.ts` - serverHttpClient化
+- [x] `post-login.ts` - serverHttpClient化
+- [x] `post-signup.ts` - serverHttpClient化
+- [x] `post-task-create.ts` - serverHttpClient化
 
 ### クリーンアップ
 - [x] `src/util/fetch-comment.ts` 削除 - useCommentMutationに置換
@@ -85,6 +88,8 @@ queries / mutations
 api (adapters, fetchers)
     ↓ (client経由)
 infra (http, time)
+  ├── httpClient (クライアント用)
+  └── serverHttpClient (Server Actions用)
 
 domain ← 全層から参照可能（逆方向禁止）
 ```

--- a/src/api/get-account-status.ts
+++ b/src/api/get-account-status.ts
@@ -1,17 +1,19 @@
 'use server';
 
-import { ErrorResponse, MemberStatus, ApiResult } from '@/src/types';
+import { serverHttpClient } from '@/src/infra/http';
+import { MemberStatus, ApiResult, ErrorResponse } from '@/src/types';
 
 export async function getAccountStatus(): Promise<ApiResult<MemberStatus[]>> {
-  const res = await fetch(`${process.env.API_HOST}/accounts`, {
-    next: { revalidate: 300 }, // 5分ごとに再検証
+  const result = await serverHttpClient.get<MemberStatus[]>('/accounts', {
+    revalidate: 300, // 5分ごとに再検証
   });
 
-  if (res.ok) {
-    const result = (await res.json()) as unknown;
-    return result as MemberStatus[];
-  } else {
-    const errors = (await res.json()) as unknown;
-    return errors as ErrorResponse;
+  if (result.ok) {
+    return result.value;
   }
+
+  const errorResponse: ErrorResponse = {
+    message: result.error.message,
+  };
+  return errorResponse;
 }

--- a/src/api/get-account-tasks.ts
+++ b/src/api/get-account-tasks.ts
@@ -1,17 +1,16 @@
 'use server';
 
-import { Task } from '../types';
+import { serverHttpClient } from '@/src/infra/http';
+import { Task } from '@/src/types';
 
 export const getAccountTasks = async (id: string): Promise<Task[]> => {
-  try {
-    const res = await fetch(`${process.env.API_HOST}/account/tasks?id=${id}`, {
-      // next: { revalidate: 60 }, // 1分ごとに再検証
-      cache: 'no-store',
-    });
-    const result: Task[] = (await res.json()) as Task[];
-    return result;
-  } catch (err) {
-    console.error('Failed to fetch account tasks:', err);
-    return [];
+  const result = await serverHttpClient.get<Task[]>(`/account/tasks?id=${id}`, {
+    cache: 'no-store',
+  });
+
+  if (result.ok) {
+    return result.value;
   }
+  console.error('Failed to fetch account tasks:', result.error.message);
+  return [];
 };

--- a/src/api/get-account.ts
+++ b/src/api/get-account.ts
@@ -1,22 +1,21 @@
 'use server';
 
-import { AccountData } from '../types';
-import { getCookies } from '../util/cookies';
+import { serverHttpClient } from '@/src/infra/http';
+import { AccountData } from '@/src/types';
+import { getCookies } from '@/src/util/cookies';
 
-type response = {
+type AccountResponse = {
   account: AccountData;
 };
 
-export const getAccount = async () => {
+export const getAccount = async (): Promise<AccountData | null> => {
   const token = getCookies('token');
-  const res = await fetch(`${process.env.API_HOST}/account`, {
+  const result = await serverHttpClient.get<AccountResponse>('/account', {
     headers: { Authorization: `Bearer ${token}` },
   });
 
-  if (!res.ok) {
-    return null;
-  } else {
-    const currentAccount: response = (await res.json()) as response;
-    return currentAccount.account;
+  if (result.ok) {
+    return result.value.account;
   }
+  return null;
 };

--- a/src/api/get-areas.ts
+++ b/src/api/get-areas.ts
@@ -1,20 +1,13 @@
 'use server';
 
-import { Area } from '../types';
+import { serverHttpClient } from '@/src/infra/http';
+import { Area } from '@/src/types';
 
-export const getAreas = async () => {
-  try {
-    const res = await fetch(`${process.env.API_HOST}/areas`, {
-      method: 'GET',
-    });
-    if (res.ok) {
-      const result: Area[] = (await res.json()) as Area[];
-      return result;
-    } else {
-      return [];
-    }
-  } catch (err) {
-    console.error(err);
-    return [];
+export const getAreas = async (): Promise<Area[]> => {
+  const result = await serverHttpClient.get<Area[]>('/areas');
+
+  if (result.ok) {
+    return result.value;
   }
+  return [];
 };

--- a/src/api/get-tasks.ts
+++ b/src/api/get-tasks.ts
@@ -1,16 +1,15 @@
 'use server';
 
-import { Task } from '../types';
+import { serverHttpClient } from '@/src/infra/http';
+import { Task } from '@/src/types';
 
 export async function getTasks(): Promise<Task[]> {
-  const res = await fetch(`${process.env.API_HOST}/tasks?type=all`, {
+  const result = await serverHttpClient.get<Task[]>('/tasks?type=all', {
     cache: 'no-store',
   });
 
-  if (res.ok) {
-    const result: Task[] = (await res.json()) as Task[];
-    return result;
-  } else {
-    return [];
+  if (result.ok) {
+    return result.value;
   }
+  return [];
 }

--- a/src/api/get-unfulfilled-count.ts
+++ b/src/api/get-unfulfilled-count.ts
@@ -1,17 +1,19 @@
 'use server';
 
-import { ApiResult } from '@/src/types';
+import { serverHttpClient } from '@/src/infra/http';
+import { ApiResult, ErrorResponse } from '@/src/types';
 
 export async function getUnfulfilledCount(): Promise<ApiResult<number>> {
-  const res = await fetch(`${process.env.API_HOST}/unfulfilled-count`, {
-    next: { revalidate: 60 }, // 1分ごとに再検証
+  const result = await serverHttpClient.get<number>('/unfulfilled-count', {
+    revalidate: 60, // 1分ごとに再検証
   });
 
-  if (res.ok) {
-    const unfulfilledCount: number = (await res.json()) as number;
-    return unfulfilledCount;
-  } else {
-    const errors = (await res.json()) as ApiResult<number>;
-    return errors;
+  if (result.ok) {
+    return result.value;
   }
+
+  const errorResponse: ErrorResponse = {
+    message: result.error.message,
+  };
+  return errorResponse;
 }

--- a/src/api/get-week-complete.ts
+++ b/src/api/get-week-complete.ts
@@ -1,17 +1,19 @@
 'use server';
 
-import { WeekCompleteData, ApiResult } from '@/src/types';
+import { serverHttpClient } from '@/src/infra/http';
+import { WeekCompleteData, ApiResult, ErrorResponse } from '@/src/types';
 
 export async function getWeekComplete(): Promise<ApiResult<WeekCompleteData>> {
-  const res = await fetch(`${process.env.API_HOST}/completed-data`, {
-    next: { revalidate: 300 }, // 5分ごとに再検証
+  const result = await serverHttpClient.get<WeekCompleteData>('/completed-data', {
+    revalidate: 300, // 5分ごとに再検証
   });
 
-  if (res.ok) {
-    const result: WeekCompleteData = (await res.json()) as WeekCompleteData;
-    return result;
-  } else {
-    const errors = (await res.json()) as ApiResult<WeekCompleteData>;
-    return errors;
+  if (result.ok) {
+    return result.value;
   }
+
+  const errorResponse: ErrorResponse = {
+    message: result.error.message,
+  };
+  return errorResponse;
 }

--- a/src/api/post-login.ts
+++ b/src/api/post-login.ts
@@ -1,5 +1,7 @@
 'use server';
 
+import { serverHttpClient } from '@/src/infra/http';
+
 export interface Account {
   id: string;
   role: string;
@@ -7,22 +9,19 @@ export interface Account {
   name: string;
 }
 
-export async function postLogin(name: string, password: string) {
-  try {
-    const res = await fetch(`${process.env.API_HOST}/account/login`, {
-      method: 'POST',
-      cache: 'no-store',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        account: { name: name, password: password },
-      }),
-    });
-    const account: Account = (await res.json()) as Account;
-    return account;
-  } catch (err) {
-    console.error(err);
-    return {};
+export async function postLogin(
+  name: string,
+  password: string,
+): Promise<Account | Record<string, never>> {
+  const result = await serverHttpClient.post<Account>(
+    '/account/login',
+    { account: { name, password } },
+    { cache: 'no-store' },
+  );
+
+  if (result.ok) {
+    return result.value;
   }
+  console.error('Login failed:', result.error.message);
+  return {};
 }

--- a/src/api/post-signup.ts
+++ b/src/api/post-signup.ts
@@ -1,6 +1,7 @@
 'use server';
 
-import { AccountData } from '../types';
+import { serverHttpClient } from '@/src/infra/http';
+import { AccountData } from '@/src/types';
 
 export const postSignup = async (
   name: string,
@@ -8,28 +9,24 @@ export const postSignup = async (
   area: string[],
   role: string,
   capacity: number,
-) => {
-  try {
-    const res = await fetch(`${process.env.API_HOST}/accounts`, {
-      method: 'POST',
-      cache: 'no-store',
-      headers: {
-        'Content-Type': 'application/json',
+): Promise<AccountData | Record<string, never>> => {
+  const result = await serverHttpClient.post<AccountData>(
+    '/accounts',
+    {
+      account: {
+        name,
+        password,
+        area,
+        role,
+        capacity,
       },
-      body: JSON.stringify({
-        account: {
-          name: name,
-          password: password,
-          area: area,
-          role: role,
-          capacity: capacity,
-        },
-      }),
-    });
-    const account: AccountData = (await res.json()) as AccountData;
-    return account;
-  } catch (err) {
-    console.error(err);
-    return {};
+    },
+    { cache: 'no-store' },
+  );
+
+  if (result.ok) {
+    return result.value;
   }
+  console.error('Signup failed:', result.error.message);
+  return {};
 };

--- a/src/api/post-task-create.ts
+++ b/src/api/post-task-create.ts
@@ -1,27 +1,25 @@
 'use server';
 
-export interface Task {
-  [key: string]: string;
-}
+import { serverHttpClient } from '@/src/infra/http';
 
-const postTaskCreate = async (name: string) => {
-  try {
-    const res = await fetch(`${process.env.API_HOST}/tasks`, {
-      method: 'POST',
-      cache: 'no-store',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        task: { task_title: name },
-      }),
-    });
-    const result: Task = (await res.json()) as Task;
-    return result;
-  } catch (err) {
-    console.error(err);
-    return {};
+type TaskResponse = {
+  [key: string]: string;
+};
+
+const postTaskCreate = async (
+  name: string,
+): Promise<TaskResponse | Record<string, never>> => {
+  const result = await serverHttpClient.post<TaskResponse>(
+    '/tasks',
+    { task: { task_title: name } },
+    { cache: 'no-store' },
+  );
+
+  if (result.ok) {
+    return result.value;
   }
+  console.error('Task creation failed:', result.error.message);
+  return {};
 };
 
 export default postTaskCreate;

--- a/src/infra/http/index.ts
+++ b/src/infra/http/index.ts
@@ -1,1 +1,2 @@
 export { httpClient } from './client';
+export { serverHttpClient } from './serverClient';

--- a/src/infra/http/serverClient.ts
+++ b/src/infra/http/serverClient.ts
@@ -1,0 +1,119 @@
+/**
+ * Server Actions用HTTPクライアント
+ * Next.js Server Components/Actionsから外部APIを呼び出す際に使用
+ */
+
+import {
+  Result,
+  ok,
+  err,
+  createApiError,
+  createNetworkError,
+} from '@/src/domain/types/error';
+
+type CacheOption = 'force-cache' | 'no-store';
+
+type ServerRequestOptions = {
+  headers?: Record<string, string>;
+  cache?: CacheOption;
+  revalidate?: number; // seconds
+};
+
+/**
+ * API_HOSTを取得（環境変数）
+ */
+const getApiHost = (): string => {
+  const host = process.env.API_HOST;
+  if (!host) {
+    throw new Error('API_HOST environment variable is not set');
+  }
+  return host;
+};
+
+/**
+ * Next.js fetch optionsを構築
+ */
+const buildFetchOptions = (
+  options?: ServerRequestOptions,
+): RequestInit & { next?: { revalidate: number } } => {
+  const fetchOptions: RequestInit & { next?: { revalidate: number } } = {};
+
+  if (options?.cache) {
+    fetchOptions.cache = options.cache;
+  }
+
+  if (options?.revalidate !== undefined) {
+    fetchOptions.next = { revalidate: options.revalidate };
+  }
+
+  return fetchOptions;
+};
+
+/**
+ * Server Actions用HTTPクライアント
+ * 全てのHTTPリクエストをResult型で返す
+ */
+export const serverHttpClient = {
+  /**
+   * GETリクエスト
+   */
+  get: async <T>(
+    path: string,
+    options?: ServerRequestOptions,
+  ): Promise<Result<T>> => {
+    try {
+      const url = `${getApiHost()}${path}`;
+      const fetchOptions = buildFetchOptions(options);
+
+      const res = await fetch(url, {
+        method: 'GET',
+        headers: options?.headers,
+        ...fetchOptions,
+      });
+
+      if (!res.ok) {
+        const message = await res.text().catch(() => 'Unknown error');
+        return err(createApiError(res.status, message));
+      }
+
+      const data = (await res.json()) as T;
+      return ok(data);
+    } catch (e) {
+      return err(createNetworkError(String(e)));
+    }
+  },
+
+  /**
+   * POSTリクエスト
+   */
+  post: async <T>(
+    path: string,
+    body?: unknown,
+    options?: ServerRequestOptions,
+  ): Promise<Result<T>> => {
+    try {
+      const url = `${getApiHost()}${path}`;
+      const fetchOptions = buildFetchOptions(options);
+
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...options?.headers,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+        ...fetchOptions,
+      });
+
+      if (!res.ok) {
+        const message = await res.text().catch(() => 'Unknown error');
+        return err(createApiError(res.status, message));
+      }
+
+      const data = (await res.json()) as T;
+      return ok(data);
+    } catch (e) {
+      return err(createNetworkError(String(e)));
+    }
+  },
+};


### PR DESCRIPTION
変更内容:
- src/infra/http/serverClient.ts 新規作成（Server Actions用HTTPクライアント）
- 全Server ActionsをserverHttpClient使用に統一
  - get-account-status.ts
  - get-account-tasks.ts
  - get-account.ts
  - get-areas.ts
  - get-tasks.ts
  - get-unfulfilled-count.ts
  - get-week-complete.ts
  - post-login.ts
  - post-signup.ts
  - post-task-create.ts

変更理由:
- FP境界分離アーキテクチャに従い、HTTP通信をinfra層に統一
- Result型によるエラーハンドリングの一貫性確保
- Next.js fetchオプション（cache, revalidate）のサポート

影響範囲:
- src/infra/http/serverClient.ts（新規）
- src/api/*.ts（10ファイル）

テスト結果: Pass（57件）