### PR TITLE
test: mutation hooks テスト追加（useCommentMutation, useFileUpload, useAcco…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,8 +19,6 @@
 - [ ] `src/queries/useTaskDetail.ts` - hookテスト
 - [ ] `src/queries/useWeekComplete.ts` - hookテスト
 - [ ] `src/mutations/useTaskMutation.ts` - hookテスト
-- [ ] `src/mutations/useCommentMutation.ts` - hookテスト
-- [ ] `src/mutations/useFileUpload.ts` - hookテスト
 
 ### 2. エラー表示UI改善
 - [ ] トースト通知コンポーネント追加
@@ -69,6 +67,9 @@
 - [x] `src/domain/functions/date.ts` - 純粋関数テスト（21件）
 - [x] `src/infra/http/client.ts` - httpClientテスト（16件）
 - [x] `src/infra/http/serverClient.ts` - serverHttpClientテスト（12件）
+- [x] `src/mutations/useCommentMutation.ts` - hookテスト（8件）
+- [x] `src/mutations/useFileUpload.ts` - hookテスト（9件）
+- [x] `src/mutations/useAccountMutation.ts` - hookテスト（5件）
 
 ### クリーンアップ
 - [x] `src/util/fetch-comment.ts` 削除 - useCommentMutationに置換
@@ -103,5 +104,8 @@ domain ← 全層から参照可能（逆方向禁止）
 | domain/functions/date | 21件 |
 | infra/http/client | 16件 |
 | infra/http/serverClient | 12件 |
+| mutations/useCommentMutation | 8件 |
+| mutations/useFileUpload | 9件 |
+| mutations/useAccountMutation | 5件 |
 | コンポーネント | 57件 |
-| **合計** | **106件** |
+| **合計** | **128件** |

--- a/src/__tests__/mutations/useAccountMutation.test.ts
+++ b/src/__tests__/mutations/useAccountMutation.test.ts
@@ -1,0 +1,91 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAccountMutation } from '@/src/mutations/useAccountMutation';
+import { httpClient } from '@/src/infra/http';
+
+// httpClientをモック
+jest.mock('@/src/infra/http', () => ({
+  httpClient: {
+    delete: jest.fn(),
+  },
+}));
+
+const mockHttpClient = httpClient as jest.Mocked<typeof httpClient>;
+
+describe('useAccountMutation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('deleteAccount', () => {
+    test('returns success result on successful deletion', async () => {
+      mockHttpClient.delete.mockResolvedValueOnce({
+        ok: true,
+        value: {},
+      });
+
+      const { result } = renderHook(() => useAccountMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.deleteAccount(123);
+      });
+
+      expect(response).toEqual({ success: true });
+      expect(mockHttpClient.delete).toHaveBeenCalledWith('/api/account/123');
+    });
+
+    test('returns error result on failure', async () => {
+      mockHttpClient.delete.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'api', status: 404, message: 'Account not found' },
+      });
+
+      const { result } = renderHook(() => useAccountMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.deleteAccount(999);
+      });
+
+      expect(response).toEqual({ success: false, error: 'Account not found' });
+    });
+
+    test('returns error result on forbidden', async () => {
+      mockHttpClient.delete.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'api', status: 403, message: 'Forbidden' },
+      });
+
+      const { result } = renderHook(() => useAccountMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.deleteAccount(1);
+      });
+
+      expect(response).toEqual({ success: false, error: 'Forbidden' });
+    });
+
+    test('calls correct API endpoint with account ID', async () => {
+      mockHttpClient.delete.mockResolvedValueOnce({
+        ok: true,
+        value: {},
+      });
+
+      const { result } = renderHook(() => useAccountMutation());
+
+      await act(async () => {
+        await result.current.deleteAccount(456);
+      });
+
+      expect(mockHttpClient.delete).toHaveBeenCalledWith('/api/account/456');
+    });
+  });
+
+  test('hook returns deleteAccount function', () => {
+    const { result } = renderHook(() => useAccountMutation());
+
+    expect(result.current.deleteAccount).toBeDefined();
+    expect(typeof result.current.deleteAccount).toBe('function');
+  });
+});

--- a/src/__tests__/mutations/useCommentMutation.test.ts
+++ b/src/__tests__/mutations/useCommentMutation.test.ts
@@ -1,0 +1,142 @@
+import { renderHook, act } from '@testing-library/react';
+import { useCommentMutation } from '@/src/mutations/useCommentMutation';
+import { httpClient } from '@/src/infra/http';
+
+// httpClientをモック
+jest.mock('@/src/infra/http', () => ({
+  httpClient: {
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const mockHttpClient = httpClient as jest.Mocked<typeof httpClient>;
+
+describe('useCommentMutation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createComment', () => {
+    test('returns success result on successful creation', async () => {
+      const mockComment = { id: 1, content: 'Test comment' };
+      mockHttpClient.post.mockResolvedValueOnce({
+        ok: true,
+        value: mockComment,
+      });
+
+      const { result } = renderHook(() => useCommentMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.createComment('Test comment', 1, 100);
+      });
+
+      expect(response).toEqual({ success: true, data: mockComment });
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/comment', {
+        content: 'Test comment',
+        accountId: 1,
+        taskId: 100,
+      });
+    });
+
+    test('returns error result on failure', async () => {
+      mockHttpClient.post.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'api', status: 400, message: 'Bad Request' },
+      });
+
+      const { result } = renderHook(() => useCommentMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.createComment('Test', 1, 100);
+      });
+
+      expect(response).toEqual({ success: false, error: 'Bad Request' });
+    });
+  });
+
+  describe('updateComment', () => {
+    test('returns success result on successful update', async () => {
+      const mockComment = { id: 1, content: 'Updated comment' };
+      mockHttpClient.put.mockResolvedValueOnce({
+        ok: true,
+        value: mockComment,
+      });
+
+      const { result } = renderHook(() => useCommentMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.updateComment('Updated comment', 1);
+      });
+
+      expect(response).toEqual({ success: true, data: mockComment });
+      expect(mockHttpClient.put).toHaveBeenCalledWith('/api/comment', {
+        content: 'Updated comment',
+        id: 1,
+      });
+    });
+
+    test('returns error result on failure', async () => {
+      mockHttpClient.put.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'api', status: 404, message: 'Not Found' },
+      });
+
+      const { result } = renderHook(() => useCommentMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.updateComment('Updated', 999);
+      });
+
+      expect(response).toEqual({ success: false, error: 'Not Found' });
+    });
+  });
+
+  describe('deleteComment', () => {
+    test('returns success result on successful deletion', async () => {
+      mockHttpClient.delete.mockResolvedValueOnce({
+        ok: true,
+        value: { message: 'Deleted' },
+      });
+
+      const { result } = renderHook(() => useCommentMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.deleteComment(1);
+      });
+
+      expect(response).toEqual({ success: true, data: { message: 'Deleted' } });
+      expect(mockHttpClient.delete).toHaveBeenCalledWith('/api/comment?commentId=1');
+    });
+
+    test('returns error result on failure', async () => {
+      mockHttpClient.delete.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'api', status: 403, message: 'Forbidden' },
+      });
+
+      const { result } = renderHook(() => useCommentMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.deleteComment(1);
+      });
+
+      expect(response).toEqual({ success: false, error: 'Forbidden' });
+    });
+  });
+
+  test('hook returns all mutation functions', () => {
+    const { result } = renderHook(() => useCommentMutation());
+
+    expect(result.current.createComment).toBeDefined();
+    expect(result.current.updateComment).toBeDefined();
+    expect(result.current.deleteComment).toBeDefined();
+  });
+});

--- a/src/__tests__/mutations/useFileUpload.test.ts
+++ b/src/__tests__/mutations/useFileUpload.test.ts
@@ -1,0 +1,209 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useFileUpload } from '@/src/mutations/useFileUpload';
+import { httpClient } from '@/src/infra/http';
+
+// httpClientをモック
+jest.mock('@/src/infra/http', () => ({
+  httpClient: {
+    postFormData: jest.fn(),
+  },
+}));
+
+const mockHttpClient = httpClient as jest.Mocked<typeof httpClient>;
+
+// File objectをモック
+const createMockFile = (name: string): File => {
+  return new File(['test content'], name, { type: 'application/pdf' });
+};
+
+describe('useFileUpload', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('uploadFiles', () => {
+    test('returns error when no files provided', async () => {
+      const { result } = renderHook(() => useFileUpload());
+
+      let response;
+      await act(async () => {
+        response = await result.current.uploadFiles([]);
+      });
+
+      expect(response).toEqual({
+        success: false,
+        error: 'ファイルが選択されていません',
+      });
+      expect(mockHttpClient.postFormData).not.toHaveBeenCalled();
+    });
+
+    test('uploads single file successfully', async () => {
+      mockHttpClient.postFormData.mockResolvedValueOnce({ ok: true, value: {} });
+
+      const { result } = renderHook(() => useFileUpload());
+      const file = createMockFile('test.pdf');
+
+      let response;
+      await act(async () => {
+        response = await result.current.uploadFiles([file]);
+      });
+
+      expect(response).toEqual({ success: true });
+      expect(mockHttpClient.postFormData).toHaveBeenCalledTimes(1);
+      expect(mockHttpClient.postFormData).toHaveBeenCalledWith(
+        '/api/aws',
+        expect.any(FormData),
+      );
+    });
+
+    test('uploads multiple files successfully', async () => {
+      mockHttpClient.postFormData
+        .mockResolvedValueOnce({ ok: true, value: {} })
+        .mockResolvedValueOnce({ ok: true, value: {} })
+        .mockResolvedValueOnce({ ok: true, value: {} });
+
+      const { result } = renderHook(() => useFileUpload());
+      const files = [
+        createMockFile('test1.pdf'),
+        createMockFile('test2.pdf'),
+        createMockFile('test3.pdf'),
+      ];
+
+      let response;
+      await act(async () => {
+        response = await result.current.uploadFiles(files);
+      });
+
+      expect(response).toEqual({ success: true });
+      expect(mockHttpClient.postFormData).toHaveBeenCalledTimes(3);
+    });
+
+    test('returns error when upload fails', async () => {
+      mockHttpClient.postFormData.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'api', status: 500, message: 'Upload failed' },
+      });
+
+      const { result } = renderHook(() => useFileUpload());
+      const file = createMockFile('test.pdf');
+
+      let response;
+      await act(async () => {
+        response = await result.current.uploadFiles([file]);
+      });
+
+      expect(response?.success).toBe(false);
+      expect(response?.error).toContain('Failed to upload test.pdf');
+    });
+
+    test('stops uploading on first failure', async () => {
+      mockHttpClient.postFormData
+        .mockResolvedValueOnce({ ok: true, value: {} })
+        .mockResolvedValueOnce({
+          ok: false,
+          error: { type: 'api', status: 500, message: 'Error' },
+        });
+
+      const { result } = renderHook(() => useFileUpload());
+      const files = [
+        createMockFile('test1.pdf'),
+        createMockFile('test2.pdf'),
+        createMockFile('test3.pdf'),
+      ];
+
+      await act(async () => {
+        await result.current.uploadFiles(files);
+      });
+
+      // 2回目で失敗するので3回目は呼ばれない
+      expect(mockHttpClient.postFormData).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('progress state', () => {
+    test('initial state is not uploading', () => {
+      const { result } = renderHook(() => useFileUpload());
+
+      expect(result.current.progress).toEqual({
+        isUploading: false,
+        currentFile: null,
+        uploadedCount: 0,
+        totalCount: 0,
+      });
+      expect(result.current.isUploading).toBe(false);
+    });
+
+    test('updates progress during upload', async () => {
+      // 遅延を追加してprogressの更新を確認
+      mockHttpClient.postFormData.mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({ ok: true, value: {} }), 10))
+      );
+
+      const { result } = renderHook(() => useFileUpload());
+      const files = [createMockFile('test1.pdf'), createMockFile('test2.pdf')];
+
+      act(() => {
+        void result.current.uploadFiles(files);
+      });
+
+      // アップロード開始後
+      await waitFor(() => {
+        expect(result.current.progress.isUploading).toBe(true);
+      });
+
+      // アップロード完了後
+      await waitFor(() => {
+        expect(result.current.progress.isUploading).toBe(false);
+      });
+    });
+
+    test('resets progress on error', async () => {
+      mockHttpClient.postFormData.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'api', status: 500, message: 'Error' },
+      });
+
+      const { result } = renderHook(() => useFileUpload());
+      const file = createMockFile('test.pdf');
+
+      await act(async () => {
+        await result.current.uploadFiles([file]);
+      });
+
+      expect(result.current.progress).toEqual({
+        isUploading: false,
+        currentFile: null,
+        uploadedCount: 0,
+        totalCount: 0,
+      });
+    });
+
+    test('sets final progress on success', async () => {
+      mockHttpClient.postFormData
+        .mockResolvedValueOnce({ ok: true, value: {} })
+        .mockResolvedValueOnce({ ok: true, value: {} });
+
+      const { result } = renderHook(() => useFileUpload());
+      const files = [createMockFile('test1.pdf'), createMockFile('test2.pdf')];
+
+      await act(async () => {
+        await result.current.uploadFiles(files);
+      });
+
+      expect(result.current.progress).toEqual({
+        isUploading: false,
+        currentFile: null,
+        uploadedCount: 2,
+        totalCount: 2,
+      });
+    });
+  });
+
+  test('hook returns all expected properties', () => {
+    const { result } = renderHook(() => useFileUpload());
+
+    expect(result.current.uploadFiles).toBeDefined();
+    expect(result.current.progress).toBeDefined();
+    expect(result.current.isUploading).toBeDefined();
+  });
+});


### PR DESCRIPTION
…untMutation）

変更内容:
- src/__tests__/mutations/useCommentMutation.test.ts 追加（8件）
- src/__tests__/mutations/useFileUpload.test.ts 追加（9件）
- src/__tests__/mutations/useAccountMutation.test.ts 追加（5件）
- TODO.md テストカバレッジ更新（合計128件）

変更理由:
- Phase 5テスト整備の一環としてmutation hooksのテストを追加
- httpClientモックによるユニットテストで品質担保

影響範囲:
- テストファイルのみ（本番コードへの影響なし）

テスト結果: Pass 128件