### PR TITLE
feat: 撮影者管理画面のUI改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ next-env.d.ts
 
 # dev end file
 .env*.development
+CLAUDE.md

--- a/src/__tests__/admin/members.test.tsx
+++ b/src/__tests__/admin/members.test.tsx
@@ -59,10 +59,10 @@ describe('Members Component', () => {
     render(<Members />);
 
     await waitFor(() => {
-      expect(screen.getByText('現在の撮影者数：2')).toBeInTheDocument();
+      expect(screen.getByText('2名の撮影者が登録されています')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('撮影者を追加する')).toBeInTheDocument();
+    expect(screen.getByText('撮影者を追加')).toBeInTheDocument();
     expect(screen.getByTestId('member-card-1')).toBeInTheDocument();
     expect(screen.getByTestId('member-card-2')).toBeInTheDocument();
   });
@@ -71,14 +71,13 @@ describe('Members Component', () => {
     render(<Members />);
 
     await waitFor(() => {
-      expect(screen.getByText('現在の撮影者数：2')).toBeInTheDocument();
+      expect(screen.getByText('2名の撮影者が登録されています')).toBeInTheDocument();
     });
 
-    // fireEvent.click(screen.getByText('Delete'));
     fireEvent.click(screen.getByLabelText('delete1'));
 
     await waitFor(() => {
-      expect(screen.getByText('現在の撮影者数：1')).toBeInTheDocument();
+      expect(screen.getByText('1名の撮影者が登録されています')).toBeInTheDocument();
     });
 
     expect(screen.queryByTestId('member-card-1')).not.toBeInTheDocument();

--- a/src/api/get-account-status.ts
+++ b/src/api/get-account-status.ts
@@ -2,9 +2,16 @@
 
 import { serverHttpClient } from '@/src/infra/http';
 import { MemberStatus, ApiResult, ErrorResponse } from '@/src/types';
+import { getCookies } from '@/src/util/cookies';
 
 export async function getAccountStatus(): Promise<ApiResult<MemberStatus[]>> {
+  const token = getCookies('token');
+  if (!token) {
+    return null;
+  }
+
   const result = await serverHttpClient.get<MemberStatus[]>('/accounts', {
+    headers: { Authorization: `Bearer ${token}` },
     revalidate: 300, // 5分ごとに再検証
   });
 

--- a/src/app/(admin)/members/page.tsx
+++ b/src/app/(admin)/members/page.tsx
@@ -1,8 +1,21 @@
 'use client';
 
 import AddIcon from '@mui/icons-material/Add';
-import { Box, Container, Fab, Link, Toolbar, Typography } from '@mui/material';
-import { useEffect, useState } from 'react';
+import GroupIcon from '@mui/icons-material/Group';
+import SearchIcon from '@mui/icons-material/Search';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  InputAdornment,
+  Paper,
+  TextField,
+  Toolbar,
+  Typography,
+} from '@mui/material';
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
 
 import { getAccountStatus } from '@/src/api/get-account-status';
 import MemberCard from '@/src/components/MemberCard';
@@ -10,14 +23,18 @@ import { MemberStatus } from '@/src/types';
 
 const Members = () => {
   const [membersStatus, setMembersStatus] = useState<MemberStatus[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
 
   useEffect(() => {
     const fetchData = async () => {
+      setIsLoading(true);
       const response = await getAccountStatus();
 
       if (response !== undefined) {
         setMembersStatus(response as MemberStatus[]);
       }
+      setIsLoading(false);
     };
 
     void fetchData();
@@ -27,56 +44,190 @@ const Members = () => {
     setMembersStatus(membersStatus.filter((member) => member.id !== id));
   };
 
+  // 検索フィルタリング
+  const filteredMembers = useMemo(() => {
+    if (!searchQuery.trim()) return membersStatus;
+    const query = searchQuery.toLowerCase();
+    return membersStatus.filter(
+      (member) =>
+        member.name.toLowerCase().includes(query) ||
+        member.area.some((area) => area.toLowerCase().includes(query)),
+    );
+  }, [membersStatus, searchQuery]);
+
   return (
     <Box
       sx={{
         flexGrow: 1,
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        backgroundColor: '#f9f9f9',
+        minHeight: '100vh',
+        bgcolor: '#f5f7fa',
       }}
     >
-      <Box
-        component="main"
-        sx={{ backgroundColor: '#f9f9f9', flexGrow: 1, overflow: 'auto' }}
-      >
-        <Toolbar />
-        <Container
-          maxWidth="xl"
+      <Toolbar />
+      <Container maxWidth="xl" sx={{ py: 4 }}>
+        {/* ページヘッダー */}
+        <Paper
+          elevation={0}
           sx={{
-            mt: 4,
+            p: 3,
             mb: 4,
-            display: 'flex',
-            justifyContent: 'center',
-            flexDirection: 'column',
+            borderRadius: 3,
+            bgcolor: '#667eea',
+            color: 'white',
           }}
         >
-          <Box alignItems={'center'} display={'flex'}>
-            <Typography variant="h5">
-              現在の撮影者数：{membersStatus.length}
-            </Typography>
-            <Link href="/account/create">
-              <Fab
-                color="primary"
-                size="small"
-                sx={{ ml: 1 }}
-                variant="extended"
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: { xs: 'column', md: 'row' },
+              alignItems: { xs: 'flex-start', md: 'center' },
+              justifyContent: 'space-between',
+              gap: 2,
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <Box
+                sx={{
+                  bgcolor: 'rgba(255,255,255,0.2)',
+                  borderRadius: 2,
+                  p: 1.5,
+                  display: 'flex',
+                }}
               >
-                <AddIcon />
-                撮影者を追加する
-              </Fab>
+                <GroupIcon sx={{ fontSize: 32 }} />
+              </Box>
+              <Box>
+                <Typography
+                  sx={{ fontWeight: 700, fontSize: { xs: '1.5rem', md: '2rem' } }}
+                >
+                  撮影者管理
+                </Typography>
+                <Typography sx={{ opacity: 0.9, fontSize: '0.875rem' }}>
+                  {isLoading ? '読み込み中...' : `${membersStatus.length}名の撮影者が登録されています`}
+                </Typography>
+              </Box>
+            </Box>
+            <Link href="/account/create" style={{ textDecoration: 'none' }}>
+              <Button
+                size="large"
+                startIcon={<AddIcon />}
+                sx={{
+                  bgcolor: 'white',
+                  color: '#667eea',
+                  fontWeight: 600,
+                  px: 3,
+                  py: 1.5,
+                  borderRadius: 2,
+                  textTransform: 'none',
+                  '&:hover': {
+                    bgcolor: 'rgba(255,255,255,0.9)',
+                  },
+                }}
+                variant="contained"
+              >
+                撮影者を追加
+              </Button>
             </Link>
           </Box>
-          {membersStatus?.map((memberStatus) => (
-            <MemberCard
-              handleDelete={handleDelete}
-              key={memberStatus.id}
-              member={memberStatus}
-            />
-          ))}
-        </Container>
-      </Box>
+        </Paper>
+
+        {/* 検索バー */}
+        <Box sx={{ mb: 3 }}>
+          <TextField
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon sx={{ color: 'text.secondary' }} />
+                </InputAdornment>
+              ),
+            }}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="名前またはエリアで検索..."
+            size="small"
+            sx={{
+              width: { xs: '100%', sm: 320 },
+              '& .MuiOutlinedInput-root': {
+                bgcolor: 'white',
+                borderRadius: 2,
+              },
+            }}
+            value={searchQuery}
+          />
+          {searchQuery && (
+            <Typography color="text.secondary" sx={{ mt: 1 }} variant="body2">
+              {filteredMembers.length}件の結果
+            </Typography>
+          )}
+        </Box>
+
+        {/* ローディング状態 */}
+        {isLoading && (
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              py: 8,
+            }}
+          >
+            <CircularProgress size={48} />
+          </Box>
+        )}
+
+        {/* メンバーカードグリッド */}
+        {!isLoading && (
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: {
+                xs: '1fr',
+                sm: 'repeat(2, 1fr)',
+                lg: 'repeat(3, 1fr)',
+              },
+              gap: 2,
+            }}
+          >
+            {filteredMembers.map((memberStatus) => (
+              <MemberCard
+                handleDelete={handleDelete}
+                key={memberStatus.id}
+                member={memberStatus}
+              />
+            ))}
+          </Box>
+        )}
+
+        {/* 検索結果なし */}
+        {!isLoading && filteredMembers.length === 0 && (
+          <Paper
+            elevation={0}
+            sx={{
+              p: 6,
+              textAlign: 'center',
+              borderRadius: 3,
+              bgcolor: 'white',
+            }}
+          >
+            <GroupIcon sx={{ fontSize: 64, color: 'text.disabled', mb: 2 }} />
+            <Typography color="text.secondary" variant="h6">
+              {searchQuery
+                ? '検索条件に一致する撮影者が見つかりません'
+                : '撮影者がまだ登録されていません'}
+            </Typography>
+            {!searchQuery && (
+              <Link href="/account/create" style={{ textDecoration: 'none' }}>
+                <Button
+                  startIcon={<AddIcon />}
+                  sx={{ mt: 2 }}
+                  variant="contained"
+                >
+                  最初の撮影者を追加
+                </Button>
+              </Link>
+            )}
+          </Paper>
+        )}
+      </Container>
     </Box>
   );
 };

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -2,13 +2,20 @@
 
 import LogoutIcon from '@mui/icons-material/Logout';
 import MenuIcon from '@mui/icons-material/Menu';
+import PersonIcon from '@mui/icons-material/Person';
 import {
+  Avatar,
+  Box,
   Button,
+  Chip,
   Dialog,
   DialogActions,
+  DialogContent,
+  DialogContentText,
   DialogTitle,
   IconButton,
   Toolbar,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import MuiAppBar, { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar';
@@ -27,6 +34,8 @@ const AppBarContainer = styled(MuiAppBar, {
   shouldForwardProp: (prop) => prop !== 'open',
 })<AppBarProps>(({ theme, open }) => ({
   zIndex: theme.zIndex.drawer + 1,
+  backgroundColor: '#667eea',
+  boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
   transition: theme.transitions.create(['width', 'margin'], {
     easing: theme.transitions.easing.sharp,
     duration: theme.transitions.duration.leavingScreen,
@@ -40,6 +49,14 @@ const AppBarContainer = styled(MuiAppBar, {
     }),
   }),
 }));
+
+const getInitials = (name: string): string => {
+  return name.charAt(0).toUpperCase();
+};
+
+const getRoleLabel = (role: string): string => {
+  return role === 'admin' ? '管理者' : 'メンバー';
+};
 
 type Props = {
   toggleDrawer: () => void;
@@ -61,63 +78,144 @@ const AppBar = (props: Props) => {
 
   return (
     <AppBarContainer open={props.open} position="fixed">
-      <Toolbar>
-        {props.role === 'admin' ? (
-          <IconButton
-            aria-label="open drawer"
-            color="inherit"
-            edge="start"
-            onClick={props.toggleDrawer}
-            sx={{
-              marginRight: 5,
-              ...(props.open && { display: 'none' }),
-            }}
-          >
-            <MenuIcon />
-          </IconButton>
-        ) : (
-          <></>
+      <Toolbar sx={{ py: 1 }}>
+        {props.role === 'admin' && (
+          <Tooltip title="メニューを開く">
+            <IconButton
+              aria-label="open drawer"
+              color="inherit"
+              edge="start"
+              onClick={props.toggleDrawer}
+              sx={{
+                marginRight: 3,
+                bgcolor: 'rgba(255,255,255,0.1)',
+                '&:hover': {
+                  bgcolor: 'rgba(255,255,255,0.2)',
+                },
+                ...(props.open && { display: 'none' }),
+              }}
+            >
+              <MenuIcon />
+            </IconButton>
+          </Tooltip>
         )}
 
-        <Typography
-          color="inherit"
-          component="h1"
-          noWrap
-          sx={{ flexGrow: 1 }}
-          variant="h6"
-        >
-          {props.name}
-        </Typography>
-        <IconButton
-          aria-label="logout"
-          color="inherit"
-          onClick={toggledOpen}
-          type="submit"
-        >
-          <LogoutIcon />
-        </IconButton>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexGrow: 1 }}>
+          <Avatar
+            sx={{
+              width: 40,
+              height: 40,
+              bgcolor: 'rgba(255,255,255,0.2)',
+              border: '2px solid rgba(255,255,255,0.3)',
+              fontWeight: 700,
+            }}
+          >
+            {getInitials(props.name)}
+          </Avatar>
+          <Box>
+            <Typography
+              component="h1"
+              noWrap
+              sx={{
+                fontWeight: 700,
+                fontSize: '1.1rem',
+                letterSpacing: 0.5,
+              }}
+            >
+              {props.name}
+            </Typography>
+            <Chip
+              icon={<PersonIcon sx={{ fontSize: 14, color: 'inherit !important' }} />}
+              label={getRoleLabel(props.role)}
+              size="small"
+              sx={{
+                height: 20,
+                fontSize: '0.7rem',
+                bgcolor: 'rgba(255,255,255,0.2)',
+                color: 'white',
+                '& .MuiChip-label': { px: 1 },
+              }}
+            />
+          </Box>
+        </Box>
+
+        <Tooltip title="ログアウト">
+          <IconButton
+            aria-label="logout"
+            color="inherit"
+            onClick={toggledOpen}
+            sx={{
+              bgcolor: 'rgba(255,255,255,0.1)',
+              '&:hover': {
+                bgcolor: 'rgba(255,255,255,0.2)',
+              },
+            }}
+          >
+            <LogoutIcon />
+          </IconButton>
+        </Tooltip>
+
         <Dialog
-          aria-describedby="alert-dialog"
-          aria-labelledby="alert-dialog"
-          fullWidth
+          aria-describedby="logout-dialog-description"
+          aria-labelledby="logout-dialog-title"
+          maxWidth="xs"
           onClose={toggledOpen}
           open={open}
+          slotProps={{
+            paper: {
+              sx: {
+                borderRadius: 3,
+                p: 1,
+              },
+            },
+          }}
         >
-          <DialogTitle id="alert-dialog-title">
-            {'ログアウトしますか？'}
+          <DialogTitle
+            id="logout-dialog-title"
+            sx={{
+              fontWeight: 700,
+              textAlign: 'center',
+              pb: 1,
+            }}
+          >
+            ログアウト
           </DialogTitle>
-          <DialogActions>
-            <Button onClick={toggledOpen}>キャンセル</Button>
-            <Button autoFocus onClick={onLogout}>
+          <DialogContent>
+            <DialogContentText
+              id="logout-dialog-description"
+              sx={{ textAlign: 'center' }}
+            >
+              ログアウトしてもよろしいですか？
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions sx={{ justifyContent: 'center', gap: 1, pb: 2 }}>
+            <Button
+              onClick={toggledOpen}
+              sx={{
+                borderRadius: 2,
+                px: 3,
+              }}
+              variant="outlined"
+            >
+              キャンセル
+            </Button>
+            <Button
+              autoFocus
+              onClick={onLogout}
+              sx={{
+                borderRadius: 2,
+                px: 3,
+                bgcolor: '#667eea',
+                '&:hover': {
+                  bgcolor: '#5a6fd6',
+                },
+              }}
+              variant="contained"
+            >
               ログアウト
             </Button>
           </DialogActions>
         </Dialog>
-        {/* <IconButton color="inherit">
-          <Badge badgeContent={4} color="secondary">
-            <NotificationsIcon />
-          </Badge>
-        </IconButton> */}
       </Toolbar>
     </AppBarContainer>
   );

--- a/src/components/MemberCard.tsx
+++ b/src/components/MemberCard.tsx
@@ -1,20 +1,24 @@
 'use client';
 
+import AssignmentIcon from '@mui/icons-material/Assignment';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import CameraAltIcon from '@mui/icons-material/CameraAlt';
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import PersonIcon from '@mui/icons-material/Person';
+import SpeedIcon from '@mui/icons-material/Speed';
 import {
-  Button,
+  Avatar,
   Box,
   Card,
-  CardActions,
   CardContent,
-  CardHeader,
-  Divider,
-  Grid,
-  Paper,
-  Typography,
   Chip,
+  IconButton,
+  LinearProgress,
+  Stack,
+  Tooltip,
+  Typography,
 } from '@mui/material';
 
-import CircleRate from '@/src/components/CircleRate';
 import { useToast } from '@/src/context/ToastContext';
 import { parseIsoToYYYYMMDD } from '@/src/domain/functions/date';
 import { useAccountMutation } from '@/src/mutations';
@@ -25,9 +29,46 @@ type Props = {
   handleDelete: (id: number) => void;
 };
 
+// NG率に応じた色を返す
+const getNgRateColor = (rate: number): 'success' | 'warning' | 'error' => {
+  if (rate < 0.1) return 'success';
+  if (rate < 0.3) return 'warning';
+  return 'error';
+};
+
+// 名前からイニシャルを取得
+const getInitials = (name: string): string => {
+  return name.charAt(0).toUpperCase();
+};
+
+// 統計アイテムコンポーネント
+const StatItem = ({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+}) => (
+  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+    <Box sx={{ color: 'text.secondary', display: 'flex' }}>{icon}</Box>
+    <Box>
+      <Typography color="text.secondary" variant="caption">
+        {label}
+      </Typography>
+      <Typography fontWeight={600} variant="body2">
+        {value}
+      </Typography>
+    </Box>
+  </Box>
+);
+
 const MemberCard = (props: Props) => {
   const { deleteAccount } = useAccountMutation();
   const { showSuccess, showErrorWithRetry } = useToast();
+  const ngRatePercent = props.member.ng_rate * 100;
+  const ngRateColor = getNgRateColor(props.member.ng_rate);
 
   const onDelete = async () => {
     if (!confirm(`${props.member.name}を削除しますか？`)) {
@@ -48,69 +89,180 @@ const MemberCard = (props: Props) => {
   };
 
   return (
-    <Grid sx={{ m: 1 }} width={'95%'}>
-      <Paper elevation={2} square={false}>
-        <Card>
-          <CardHeader
-            subheader={`最終更新：${parseIsoToYYYYMMDD(props.member.updatedAt)}`}
-            title={`${props.member.name}`}
-          />
-          <Divider variant="middle" />
-          <CardContent>
-            <Box alignItems={'center'} display={'flex'}>
-              <Typography>撮影可能エリア：</Typography>
-              {props.member.area.map((areaStatus) => (
-                <Chip
-                  color="primary"
-                  key={areaStatus}
-                  label={areaStatus}
-                  sx={{ ml: 1, p: 0, height: '1.6rem' }}
-                  variant="outlined"
-                />
-              ))}
-            </Box>
-            <Box
+    <Card
+      sx={{
+        m: 1,
+        width: '100%',
+        maxWidth: 400,
+        borderRadius: 3,
+        transition: 'all 0.2s ease-in-out',
+        '&:hover': {
+          transform: 'translateY(-4px)',
+          boxShadow: '0 12px 24px rgba(0,0,0,0.1)',
+        },
+      }}
+    >
+      {/* ヘッダー部分 */}
+      <Box
+        sx={{
+          bgcolor: '#667eea',
+          p: 2.5,
+          position: 'relative',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <Avatar
+            sx={{
+              width: 56,
+              height: 56,
+              bgcolor: 'rgba(255,255,255,0.2)',
+              border: '2px solid rgba(255,255,255,0.3)',
+              fontSize: '1.5rem',
+              fontWeight: 700,
+            }}
+          >
+            {getInitials(props.member.name)}
+          </Avatar>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Typography
+              noWrap
               sx={{
+                color: 'white',
+                fontWeight: 700,
+                fontSize: '1.25rem',
+              }}
+            >
+              {props.member.name}
+            </Typography>
+            <Typography
+              sx={{
+                color: 'rgba(255,255,255,0.8)',
+                fontSize: '0.75rem',
                 display: 'flex',
                 alignItems: 'center',
-                width: '100%',
-                justifyContent: 'space-around',
-                my: 2,
+                gap: 0.5,
               }}
             >
-              <Box sx={{ width: '20%' }}>
-                <Typography>
-                  登録日：{parseIsoToYYYYMMDD(props.member.createdAt)}
-                </Typography>
-                <Typography>
-                  1日の最大撮影数：{props.member.capacity}
-                </Typography>
-                <Typography>総撮影件数：{props.member.total}</Typography>
-                <Typography>現在のアサイン数：{props.member.assign}</Typography>
-              </Box>
-              <Box sx={{ width: '20%' }}>
-                <CircleRate
-                  name="NG率"
-                  rate={props.member.ng_rate * 100}
-                  size={120}
-                />
-              </Box>
-            </Box>
-          </CardContent>
-          <CardActions>
-            <Button
-              onClick={() => {
-                void onDelete();
-              }}
+              <CalendarTodayIcon sx={{ fontSize: 14 }} />
+              登録: {parseIsoToYYYYMMDD(props.member.createdAt)}
+            </Typography>
+          </Box>
+          <Tooltip title="メンバーを削除">
+            <IconButton
+              onClick={() => void onDelete()}
               size="small"
-              variant="outlined"
+              sx={{
+                color: 'rgba(255,255,255,0.7)',
+                '&:hover': {
+                  color: 'white',
+                  bgcolor: 'rgba(255,255,255,0.1)',
+                },
+              }}
             >
-              削除
-            </Button>
-          </CardActions>
-        </Card>
-      </Paper>
-    </Grid>
+              <DeleteOutlineIcon />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      </Box>
+
+      <CardContent sx={{ p: 2.5 }}>
+        {/* エリアチップ */}
+        <Box sx={{ mb: 2.5 }}>
+          <Typography
+            color="text.secondary"
+            gutterBottom
+            sx={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5 }}
+          >
+            撮影可能エリア
+          </Typography>
+          <Stack direction="row" flexWrap="wrap" gap={0.75}>
+            {props.member.area.length > 0 ? (
+              props.member.area.map((areaStatus) => (
+                <Chip
+                  icon={<PersonIcon sx={{ fontSize: 16 }} />}
+                  key={areaStatus}
+                  label={areaStatus}
+                  size="small"
+                  sx={{
+                    bgcolor: 'primary.50',
+                    color: 'primary.main',
+                    fontWeight: 500,
+                    '& .MuiChip-icon': { color: 'primary.main' },
+                  }}
+                />
+              ))
+            ) : (
+              <Typography color="text.disabled" variant="body2">
+                未設定
+              </Typography>
+            )}
+          </Stack>
+        </Box>
+
+        {/* 統計グリッド */}
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(2, 1fr)',
+            gap: 2,
+            mb: 2.5,
+          }}
+        >
+          <StatItem
+            icon={<SpeedIcon fontSize="small" />}
+            label="1日の最大撮影数"
+            value={props.member.capacity}
+          />
+          <StatItem
+            icon={<CameraAltIcon fontSize="small" />}
+            label="総撮影件数"
+            value={props.member.total}
+          />
+          <StatItem
+            icon={<AssignmentIcon fontSize="small" />}
+            label="現在のアサイン"
+            value={props.member.assign}
+          />
+          <StatItem
+            icon={<CalendarTodayIcon fontSize="small" />}
+            label="最終更新"
+            value={parseIsoToYYYYMMDD(props.member.updatedAt)}
+          />
+        </Box>
+
+        {/* NG率プログレスバー */}
+        <Box
+          sx={{
+            bgcolor: 'grey.50',
+            borderRadius: 2,
+            p: 1.5,
+          }}
+        >
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
+            <Typography color="text.secondary" variant="caption">
+              NG率
+            </Typography>
+            <Typography
+              color={`${ngRateColor}.main`}
+              fontWeight={700}
+              variant="caption"
+            >
+              {ngRatePercent.toFixed(1)}%
+            </Typography>
+          </Box>
+          <LinearProgress
+            color={ngRateColor}
+            sx={{
+              height: 8,
+              borderRadius: 4,
+              bgcolor: 'grey.200',
+            }}
+            value={ngRatePercent}
+            variant="determinate"
+          />
+        </Box>
+      </CardContent>
+    </Card>
   );
 };
 


### PR DESCRIPTION
変更内容:
- MemberCard: モダンなカードデザインに刷新（Avatar、統計表示、NG率プログレスバー）
- members/page: グリッドレイアウト、検索機能、ローディング状態、空状態表示を追加
- AppBar: Avatar、役割チップ、改善されたログアウトダイアログを追加
- get-account-status: 認証トークンをAPIリクエストに追加
- .gitignore: CLAUDE.mdを除外

変更理由:
- 統一感のあるモダンなUIを実現
- UX向上（検索、ローディング表示、空状態表示）

影響範囲:
- src/components/MemberCard.tsx
- src/app/(admin)/members/page.tsx
- src/components/AppBar.tsx
- src/api/get-account-status.ts

テスト結果: Pass、175件