### PR TITLE
feat: ボタンデザインを新デザイン仕様に統一

### DIFF
--- a/src/app/(admin)/account/create/page.tsx
+++ b/src/app/(admin)/account/create/page.tsx
@@ -180,7 +180,19 @@ const AccountCreate = () => {
             <Button
               disabled={isSubmitting}
               size="medium"
-              sx={{ mt: 3, mb: 2 }}
+              sx={{
+                mt: 3,
+                mb: 2,
+                borderRadius: 2,
+                bgcolor: '#667eea',
+                px: 4,
+                '&:hover': {
+                  bgcolor: '#5a6fd6',
+                },
+                '&.Mui-disabled': {
+                  bgcolor: 'rgba(102, 126, 234, 0.5)',
+                },
+              }}
               type="submit"
               variant="contained"
             >

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -77,7 +77,17 @@ export default function LogIn() {
             />
             <Button
               fullWidth
-              sx={{ mt: 3, mb: 2 }}
+              sx={{
+                mt: 3,
+                mb: 2,
+                borderRadius: 2,
+                bgcolor: '#667eea',
+                py: 1.5,
+                fontWeight: 600,
+                '&:hover': {
+                  bgcolor: '#5a6fd6',
+                },
+              }}
               type="submit"
               variant="contained"
             >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,7 +94,17 @@ const SignInSide = () => {
               /> */}
               <Button
                 fullWidth
-                sx={{ mt: 3, mb: 2 }}
+                sx={{
+                  mt: 3,
+                  mb: 2,
+                  borderRadius: 2,
+                  bgcolor: '#667eea',
+                  py: 1.5,
+                  fontWeight: 600,
+                  '&:hover': {
+                    bgcolor: '#5a6fd6',
+                  },
+                }}
                 type="submit"
                 variant="contained"
               >

--- a/src/components/Buttons/BasicButton.tsx
+++ b/src/components/Buttons/BasicButton.tsx
@@ -9,7 +9,14 @@ export const BasicButton = (props: Props) => {
   return (
     <Button
       onClick={props.onClick}
-      sx={{ m: 1 }}
+      sx={{
+        m: 1,
+        borderRadius: 2,
+        bgcolor: '#667eea',
+        '&:hover': {
+          bgcolor: '#5a6fd6',
+        },
+      }}
       tabIndex={-1}
       variant="contained"
     >
@@ -22,7 +29,16 @@ export const OutlinedButton = (props: Props) => {
   return (
     <Button
       onClick={props.onClick}
-      sx={{ m: 1 }}
+      sx={{
+        m: 1,
+        borderRadius: 2,
+        borderColor: '#667eea',
+        color: '#667eea',
+        '&:hover': {
+          borderColor: '#5a6fd6',
+          bgcolor: 'rgba(102, 126, 234, 0.04)',
+        },
+      }}
       tabIndex={-1}
       variant="outlined"
     >

--- a/src/components/Buttons/UploadButton.tsx
+++ b/src/components/Buttons/UploadButton.tsx
@@ -116,6 +116,13 @@ const UploadButton = (props: Props) => {
         component="label"
         role={undefined}
         startIcon={<CloudUploadIcon />}
+        sx={{
+          borderRadius: 2,
+          bgcolor: '#667eea',
+          '&:hover': {
+            bgcolor: '#5a6fd6',
+          },
+        }}
         tabIndex={-1}
         variant="contained"
       >
@@ -136,7 +143,17 @@ const UploadButton = (props: Props) => {
       <Button
         disabled={isUploading}
         onClick={() => void onSend()}
-        sx={{ ml: 1 }}
+        sx={{
+          ml: 1,
+          borderRadius: 2,
+          bgcolor: '#667eea',
+          '&:hover': {
+            bgcolor: '#5a6fd6',
+          },
+          '&.Mui-disabled': {
+            bgcolor: 'rgba(102, 126, 234, 0.5)',
+          },
+        }}
         variant="contained"
       >
         {isUploading ? 'アップロード中...' : '送信'}
@@ -146,7 +163,19 @@ const UploadButton = (props: Props) => {
         {selectedFileArray.map((file, index) => (
           <div key={file.name}>
             <div>{file.name}</div>
-            <Button onClick={() => handleDelete(index)} variant="outlined">
+            <Button
+              onClick={() => handleDelete(index)}
+              sx={{
+                borderRadius: 2,
+                borderColor: '#667eea',
+                color: '#667eea',
+                '&:hover': {
+                  borderColor: '#5a6fd6',
+                  bgcolor: 'rgba(102, 126, 234, 0.04)',
+                },
+              }}
+              variant="outlined"
+            >
               削除
             </Button>
           </div>

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -70,7 +70,17 @@ const EditToolbar = (props: EditToolbarProps) => {
 
   return (
     <GridToolbarContainer>
-      <Button color="primary" onClick={handleClick} startIcon={<AddIcon />}>
+      <Button
+        onClick={handleClick}
+        startIcon={<AddIcon />}
+        sx={{
+          borderRadius: 2,
+          color: '#667eea',
+          '&:hover': {
+            bgcolor: 'rgba(102, 126, 234, 0.08)',
+          },
+        }}
+      >
         Add comment
       </Button>
     </GridToolbarContainer>

--- a/src/components/EmptySendDialog.tsx
+++ b/src/components/EmptySendDialog.tsx
@@ -17,20 +17,41 @@ const EmptySendDialog = (props: Props) => {
     <Dialog
       aria-describedby="empty-send-dialog"
       aria-labelledby="empty-send-dialog"
-      fullWidth
+      maxWidth="sm"
       onClose={props.toggleDialog}
       open={props.open}
+      slotProps={{
+        paper: {
+          sx: {
+            borderRadius: 3,
+          },
+        },
+      }}
     >
-      <DialogTitle id="empty-send-dialog-id">
-        {'ファイルがアップロードされていません'}
+      <DialogTitle id="empty-send-dialog-id" sx={{ fontWeight: 700 }}>
+        ファイルがアップロードされていません
       </DialogTitle>
       <DialogContent>
         <DialogContentText id="send-button-description">
           ファイルがアップロードされていない状態で送信することはできません。地域名が名前に含まれたファイルをアップロードしてください。
         </DialogContentText>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={props.toggleDialog}>閉じる</Button>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button
+          onClick={props.toggleDialog}
+          sx={{
+            borderRadius: 2,
+            bgcolor: '#667eea',
+            color: 'white',
+            px: 3,
+            '&:hover': {
+              bgcolor: '#5a6fd6',
+            },
+          }}
+          variant="contained"
+        >
+          閉じる
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/IncorrectUploadDialog.tsx
+++ b/src/components/IncorrectUploadDialog.tsx
@@ -20,22 +20,34 @@ const IncorrectUploadDialog = (props: Props) => {
     <Dialog
       aria-describedby="incorrect-upload-dialog"
       aria-labelledby="incorrect-upload-dialog"
-      fullWidth
+      maxWidth="sm"
       onClose={props.toggleDialog}
       open={props.open}
+      slotProps={{
+        paper: {
+          sx: {
+            borderRadius: 3,
+          },
+        },
+      }}
     >
-      <DialogTitle id="incorrect-upload-dialog-id">
-        {'アップロードされたファイルの形式が正しくありません'}
+      <DialogTitle id="incorrect-upload-dialog-id" sx={{ fontWeight: 700 }}>
+        アップロードされたファイルの形式が正しくありません
       </DialogTitle>
       <DialogContent>
         <Box display={'flex'} sx={{ mb: 2, flexWrap: 'wrap', rowGap: 1 }}>
           {props.areaNames?.map((name) => {
             return (
               <Chip
-                color="primary"
                 key={name}
                 label={name}
-                sx={{ ml: 1, p: 0, height: '1.6rem' }}
+                sx={{
+                  ml: 1,
+                  p: 0,
+                  height: '1.6rem',
+                  borderColor: '#667eea',
+                  color: '#667eea',
+                }}
                 variant="outlined"
               />
             );
@@ -45,8 +57,22 @@ const IncorrectUploadDialog = (props: Props) => {
           上記いずれかの地域名の含まれたファイルのみアップロードすることができます。
         </DialogContentText>
       </DialogContent>
-      <DialogActions>
-        <Button onClick={props.toggleDialog}>閉じる</Button>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button
+          onClick={props.toggleDialog}
+          sx={{
+            borderRadius: 2,
+            bgcolor: '#667eea',
+            color: 'white',
+            px: 3,
+            '&:hover': {
+              bgcolor: '#5a6fd6',
+            },
+          }}
+          variant="contained"
+        >
+          閉じる
+        </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/components/TaskList.tsx
+++ b/src/components/TaskList.tsx
@@ -94,7 +94,30 @@ const TaskList = (props: Props) => {
           <ButtonGroup
             aria-label="sort type"
             disableElevation
-            sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}
+            sx={{
+              mt: 2,
+              display: 'flex',
+              justifyContent: 'center',
+              '& .MuiButton-root': {
+                borderRadius: 0,
+                bgcolor: '#667eea',
+                '&:hover': {
+                  bgcolor: '#5a6fd6',
+                },
+                '&.Mui-disabled': {
+                  bgcolor: 'rgba(102, 126, 234, 0.5)',
+                  color: 'white',
+                },
+              },
+              '& .MuiButton-root:first-of-type': {
+                borderTopLeftRadius: 8,
+                borderBottomLeftRadius: 8,
+              },
+              '& .MuiButton-root:last-of-type': {
+                borderTopRightRadius: 8,
+                borderBottomRightRadius: 8,
+              },
+            }}
             variant="contained"
           >
             <Button
@@ -114,7 +137,30 @@ const TaskList = (props: Props) => {
             <ButtonGroup
               aria-label="data type"
               disableElevation
-              sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}
+              sx={{
+                mt: 2,
+                display: 'flex',
+                justifyContent: 'center',
+                '& .MuiButton-root': {
+                  borderRadius: 0,
+                  bgcolor: '#667eea',
+                  '&:hover': {
+                    bgcolor: '#5a6fd6',
+                  },
+                  '&.Mui-disabled': {
+                    bgcolor: 'rgba(102, 126, 234, 0.5)',
+                    color: 'white',
+                  },
+                },
+                '& .MuiButton-root:first-of-type': {
+                  borderTopLeftRadius: 8,
+                  borderBottomLeftRadius: 8,
+                },
+                '& .MuiButton-root:last-of-type': {
+                  borderTopRightRadius: 8,
+                  borderBottomRightRadius: 8,
+                },
+              }}
               variant="contained"
             >
               <Button


### PR DESCRIPTION
変更内容:
- BasicButton, OutlinedButton: プライマリカラー(#667eea)とborderRadius:2を適用
- ログインページ: Sign In/Log Inボタンに新スタイルを適用
- UploadButton: Upload file、送信、削除ボタンに新スタイルを適用
- TaskList: ButtonGroupに新スタイル（角丸、プライマリカラー）を適用
- AccountCreate: 新規作成ボタンに新スタイルを適用
- CommentList: Add commentボタンに新スタイルを適用
- EmptySendDialog, IncorrectUploadDialog: ダイアログとボタンに新スタイルを適用

変更理由:
- アプリケーション全体のUIデザイン統一
- CLAUDE.mdに記載のデザイン仕様に準拠

影響範囲:
- src/components/Buttons/BasicButton.tsx
- src/components/Buttons/UploadButton.tsx
- src/components/TaskList.tsx
- src/components/CommentList.tsx
- src/components/EmptySendDialog.tsx
- src/components/IncorrectUploadDialog.tsx
- src/app/page.tsx
- src/app/login/page.tsx
- src/app/(admin)/account/create/page.tsx

テスト結果: Pass、175件