### PR TITLE
fix: フロントエンドテストの失敗を修正

### DIFF
--- a/src/__tests__/admin/AccountCreate.test.tsx
+++ b/src/__tests__/admin/AccountCreate.test.tsx
@@ -29,16 +29,16 @@ describe('AccountCreate', () => {
 
   test('renders the component', () => {
     render(<AccountCreate />);
-    expect(screen.getByText('Create New Account')).toBeInTheDocument();
+    expect(screen.getByText('新規アカウント作成')).toBeInTheDocument();
   });
 
   test('renders form fields', () => {
     render(<AccountCreate />);
-    expect(screen.getByText('Account name')).toBeInTheDocument();
-    expect(screen.getByLabelText('password')).toBeInTheDocument();
-    expect(screen.getByText('1日当たりのキャパシティ')).toBeInTheDocument();
+    expect(screen.getByText('アカウント名')).toBeInTheDocument();
+    expect(screen.getByText('パスワード')).toBeInTheDocument();
+    expect(screen.getByText('1日あたりのキャパシティ')).toBeInTheDocument();
     expect(screen.getByText('撮影可能エリア')).toBeInTheDocument();
-    expect(screen.getByText('Role')).toBeInTheDocument();
+    expect(screen.getByText('権限')).toBeInTheDocument();
   });
 
   test('renders AreaListCheck and RoleRadioButton components', () => {
@@ -49,7 +49,7 @@ describe('AccountCreate', () => {
 
   test('shows error when name is empty', async () => {
     render(<AccountCreate />);
-    const submitButton = screen.getByRole('button', { name: '新規作成' });
+    const submitButton = screen.getByRole('button', { name: /アカウントを作成/i });
 
     fireEvent.click(submitButton);
 
@@ -62,9 +62,9 @@ describe('AccountCreate', () => {
 
   test('shows error when password is too short', async () => {
     render(<AccountCreate />);
-    const nameInput = screen.getByLabelText(/Account Name/i, { selector: 'input' });
-    const passwordInput = screen.getByLabelText(/password/i, { selector: 'input' });
-    const submitButton = screen.getByRole('button', { name: '新規作成' });
+    const nameInput = screen.getByPlaceholderText('例: 山田太郎');
+    const passwordInput = document.querySelector('input[name="password"]') as HTMLInputElement;
+    const submitButton = screen.getByRole('button', { name: /アカウントを作成/i });
 
     fireEvent.change(nameInput, { target: { value: 'TestUser' } });
     fireEvent.change(passwordInput, { target: { value: 'short' } });
@@ -80,10 +80,10 @@ describe('AccountCreate', () => {
 
   test('shows error when capacity is invalid', async () => {
     render(<AccountCreate />);
-    const nameInput = screen.getByLabelText(/Account Name/i, { selector: 'input' });
-    const passwordInput = screen.getByLabelText(/password/i, { selector: 'input' });
+    const nameInput = screen.getByPlaceholderText('例: 山田太郎');
+    const passwordInput = document.querySelector('input[name="password"]') as HTMLInputElement;
     const capacityInput = screen.getByRole('spinbutton');
-    const submitButton = screen.getByRole('button', { name: '新規作成' });
+    const submitButton = screen.getByRole('button', { name: /アカウントを作成/i });
 
     fireEvent.change(nameInput, { target: { value: 'TestUser' } });
     fireEvent.change(passwordInput, { target: { value: 'Password123' } });
@@ -100,10 +100,10 @@ describe('AccountCreate', () => {
 
   test('submits form with correct data', async () => {
     render(<AccountCreate />);
-    const nameInput = screen.getByLabelText(/Account Name/i, { selector: 'input' });
-    const passwordInput = screen.getByLabelText(/password/i, { selector: 'input' });
+    const nameInput = screen.getByPlaceholderText('例: 山田太郎');
+    const passwordInput = document.querySelector('input[name="password"]') as HTMLInputElement;
     const capacityInput = screen.getByRole('spinbutton');
-    const submitButton = screen.getByRole('button', { name: '新規作成' });
+    const submitButton = screen.getByRole('button', { name: /アカウントを作成/i });
 
     // 必須フィールドを入力
     fireEvent.change(nameInput, { target: { value: 'TestUser' } });

--- a/src/__tests__/components/Details/AdminDetail.test.tsx
+++ b/src/__tests__/components/Details/AdminDetail.test.tsx
@@ -77,8 +77,8 @@ describe('AdminDetail', () => {
   it('renders correctly when loaded', () => {
     render(<AdminDetail {...mockProps} />);
 
-    expect(screen.getByText('Open File in New Tab')).toBeInTheDocument();
-    expect(screen.getByText('登録日時：2023-01-01')).toBeInTheDocument();
+    expect(screen.getByText('ファイルを開く')).toBeInTheDocument();
+    expect(screen.getByText('登録日: 2023-01-01')).toBeInTheDocument();
     expect(screen.getByTestId('comment-list')).toBeInTheDocument();
   });
 

--- a/src/__tests__/components/Details/MemberDetail.test.tsx
+++ b/src/__tests__/components/Details/MemberDetail.test.tsx
@@ -80,8 +80,8 @@ describe('MemberDetail', () => {
   it('renders correctly when loaded', () => {
     render(<MemberDetail {...mockProps} />);
 
-    expect(screen.getByText('Open File in New Tab')).toBeInTheDocument();
-    expect(screen.getByText('振り分け日時：2023-01-01')).toBeInTheDocument();
+    expect(screen.getByText('ファイルを開く')).toBeInTheDocument();
+    expect(screen.getByText('振り分け日: 2023-01-01')).toBeInTheDocument();
     expect(screen.getByTestId('comment-list')).toBeInTheDocument();
     expect(screen.getByText('完了')).toBeInTheDocument();
     expect(screen.getByText('NG')).toBeInTheDocument();

--- a/src/__tests__/components/TaskAccordion.test.tsx
+++ b/src/__tests__/components/TaskAccordion.test.tsx
@@ -16,9 +16,22 @@ jest.mock('@/src/context/ToastContext', () => ({
   }),
 }));
 
-// モックの関数とデータを準備
-const mockFetch = jest.fn();
-global.fetch = mockFetch;
+// useTaskDetailをモック
+const mockFetchData = jest.fn();
+const mockCleanup = jest.fn();
+
+jest.mock('@/src/queries', () => ({
+  useTaskDetail: () => ({
+    fileUrl: 'http://example.com/file',
+    comments: [{ id: 1, content: 'Test Comment' }],
+    isLoaded: true,
+    isLoading: false,
+    error: null,
+    fetchData: mockFetchData,
+    cleanup: mockCleanup,
+  }),
+  isTaskDetailCached: () => false,
+}));
 
 const mockAccount: AccountData = {
   id: 1,
@@ -42,7 +55,8 @@ const mockMutate = jest.fn();
 
 describe('TaskAccordion', () => {
   beforeEach(() => {
-    mockFetch.mockClear();
+    mockFetchData.mockClear();
+    mockCleanup.mockClear();
     mockReload.mockClear();
     mockMutate.mockClear();
   });
@@ -65,14 +79,6 @@ describe('TaskAccordion', () => {
   });
 
   test('expands accordion and fetches data on click', async () => {
-    mockFetch
-      .mockResolvedValueOnce({
-        json: () => Promise.resolve('http://example.com/file'),
-      })
-      .mockResolvedValueOnce({
-        json: () => Promise.resolve([{ id: 1, content: 'Test Comment' }]),
-      });
-
     render(
       <TaskAccordion
         account={mockAccount}
@@ -90,15 +96,7 @@ describe('TaskAccordion', () => {
     fireEvent.click(accordionSummary);
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(mockFetch).toHaveBeenCalledWith(
-        '/api/aws?key=Test Task',
-        expect.any(Object),
-      );
-      expect(mockFetch).toHaveBeenCalledWith(
-        '/api/comments?taskId=1&accountId=1',
-        expect.any(Object),
-      );
+      expect(mockFetchData).toHaveBeenCalled();
     });
   });
 
@@ -117,7 +115,7 @@ describe('TaskAccordion', () => {
     );
 
     // MemberDetailコンポーネントの特定の要素をチェック
-    expect(screen.getByText('Open File in New Tab')).toBeInTheDocument();
+    expect(screen.getByText('ファイルを開く')).toBeInTheDocument();
   });
 
   test('renders AdminDetail for admin type', () => {
@@ -136,6 +134,6 @@ describe('TaskAccordion', () => {
 
     // AdminDetailコンポーネントの特定の要素をチェック
     // 注意: これはAdminDetailコンポーネントの実装に依存します
-    expect(screen.getByText('Open File in New Tab')).toBeInTheDocument();
+    expect(screen.getByText('ファイルを開く')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/TaskList.test.tsx
+++ b/src/__tests__/components/TaskList.test.tsx
@@ -16,7 +16,7 @@ jest.mock('@/src/queries', () => ({
 // TaskAccordionをモック
 jest.mock('@/src/components/TaskAccordion', () => {
   return function MockTaskAccordion({ task }: { task: Task }) {
-    return <div data-testid={`task-${task.id}`}>{task.title}</div>;
+    return <div data-testid={`task-${task.id}`}>{task.task_title}</div>;
   };
 });
 
@@ -46,7 +46,7 @@ const mockAdminAccount: AccountData = {
 const mockTasks: Task[] = [
   {
     id: 1,
-    title: 'Task 1',
+    task_title: 'Task 1',
     area_name: 'Area A',
     assign_cycle_id: 1,
     created_at: '2023-01-01T00:00:00Z',
@@ -54,7 +54,7 @@ const mockTasks: Task[] = [
   },
   {
     id: 2,
-    title: 'Task 2',
+    task_title: 'Task 2',
     area_name: 'Area B',
     assign_cycle_id: 2,
     created_at: '2023-01-02T00:00:00Z',
@@ -211,8 +211,8 @@ describe('TaskList', () => {
       expect(screen.getByText('Task 1')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText('地域'));
+    fireEvent.click(screen.getByText('地域順'));
 
-    expect(screen.getByText('地域')).toBeDisabled();
+    expect(screen.getByText('地域順')).toBeDisabled();
   });
 });

--- a/src/__tests__/queries/useTaskDetail.test.ts
+++ b/src/__tests__/queries/useTaskDetail.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
-import { useTaskDetail } from '@/src/queries/useTaskDetail';
+import { useTaskDetail, clearTaskDetailCache } from '@/src/queries/useTaskDetail';
 import { httpClient } from '@/src/infra/http';
 
 // httpClientをモック
@@ -19,6 +19,7 @@ const mockComments = [
 describe('useTaskDetail', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    clearTaskDetailCache();
   });
 
   describe('initial state', () => {

--- a/src/queries/useTaskDetail.ts
+++ b/src/queries/useTaskDetail.ts
@@ -25,6 +25,12 @@ export const isTaskDetailCached = (taskId: number): boolean => {
   return taskDetailCache.has(String(taskId));
 };
 
+/** キャッシュをクリア（テスト用） */
+export const clearTaskDetailCache = (): void => {
+  taskDetailCache.clear();
+  fetchingTasks.clear();
+};
+
 /**
  * タスク詳細データ（ファイルURL・コメント）の遅延読み込み用hook
  * アコーディオン展開時に手動でfetchをトリガー


### PR DESCRIPTION
## Summary
- UIの日本語化に伴い失敗していた16件のフロントエンドテストを修正
- AccountCreate、AdminDetail、MemberDetail、TaskList、TaskAccordion、useTaskDetailのテストを更新
- useTaskDetailにテスト用キャッシュクリア関数を追加

## 変更内容
- **AccountCreate.test.tsx**: 英語ラベル→日本語ラベル（Create New Account → 新規アカウント作成等）
- **AdminDetail.test.tsx/MemberDetail.test.tsx**: ボタンテキスト・日付フォーマットを実装に合わせて修正
- **TaskList.test.tsx**: 「地域」→「地域順」に修正
- **TaskAccordion.test.tsx**: global.fetchモックからuseTaskDetailモックに変更、Task型のtitle使用に修正
- **useTaskDetail.ts**: テスト用キャッシュクリア関数(clearTaskDetailCache)を追加
- **useTaskDetail.test.ts**: beforeEachでキャッシュクリアを実行

## Test plan
- [x] npm test: 175件 Pass
- [x] ESLint: Pass