### PR TITLE
feat: バックエンド破壊的変更への対応（認証必須化）

### DIFF
--- a/src/__tests__/domain/types/error.test.ts
+++ b/src/__tests__/domain/types/error.test.ts
@@ -4,9 +4,11 @@ import {
   createNetworkError,
   DomainError,
   err,
+  isBadRequest,
   isConflict,
   isDomainError,
   isForbidden,
+  isNotFound,
   isServiceUnavailable,
   isUnauthorized,
   NetworkError,
@@ -88,6 +90,23 @@ describe('error helpers', () => {
     });
   });
 
+  describe('isBadRequest', () => {
+    test('400 APIエラーをtrueと判定', () => {
+      const error: DomainError = { type: 'api', status: 400, message: 'Bad Request' };
+      expect(isBadRequest(error)).toBe(true);
+    });
+
+    test('他のステータスコードはfalse', () => {
+      const error: DomainError = { type: 'api', status: 401, message: 'Unauthorized' };
+      expect(isBadRequest(error)).toBe(false);
+    });
+
+    test('NetworkErrorはfalse', () => {
+      const error: DomainError = { type: 'network', message: 'Error' };
+      expect(isBadRequest(error)).toBe(false);
+    });
+  });
+
   describe('isUnauthorized', () => {
     test('401 APIエラーをtrueと判定', () => {
       const error: DomainError = { type: 'api', status: 401, message: 'Unauthorized' };
@@ -119,6 +138,23 @@ describe('error helpers', () => {
     test('NetworkErrorはfalse', () => {
       const error: DomainError = { type: 'network', message: 'Error' };
       expect(isForbidden(error)).toBe(false);
+    });
+  });
+
+  describe('isNotFound', () => {
+    test('404 APIエラーをtrueと判定', () => {
+      const error: DomainError = { type: 'api', status: 404, message: 'Not Found' };
+      expect(isNotFound(error)).toBe(true);
+    });
+
+    test('他のステータスコードはfalse', () => {
+      const error: DomainError = { type: 'api', status: 400, message: 'Bad Request' };
+      expect(isNotFound(error)).toBe(false);
+    });
+
+    test('NetworkErrorはfalse', () => {
+      const error: DomainError = { type: 'network', message: 'Error' };
+      expect(isNotFound(error)).toBe(false);
     });
   });
 

--- a/src/__tests__/domain/types/error.test.ts
+++ b/src/__tests__/domain/types/error.test.ts
@@ -1,0 +1,158 @@
+import {
+  ApiError,
+  createApiError,
+  createNetworkError,
+  DomainError,
+  err,
+  isConflict,
+  isDomainError,
+  isForbidden,
+  isServiceUnavailable,
+  isUnauthorized,
+  NetworkError,
+  ok,
+  toDisplayError,
+} from '@/src/domain/types/error';
+
+describe('error helpers', () => {
+  describe('ok / err', () => {
+    test('okは成功結果を返す', () => {
+      const result = ok('success');
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toBe('success');
+      }
+    });
+
+    test('errは失敗結果を返す', () => {
+      const error: ApiError = { type: 'api', status: 500, message: 'Error' };
+      const result = err(error);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toEqual(error);
+      }
+    });
+  });
+
+  describe('createApiError', () => {
+    test('ApiErrorを生成する', () => {
+      const error = createApiError(404, 'Not Found', { path: '/users' });
+      expect(error.type).toBe('api');
+      expect(error.status).toBe(404);
+      expect(error.message).toBe('Not Found');
+      expect(error.details).toEqual({ path: '/users' });
+    });
+  });
+
+  describe('createNetworkError', () => {
+    test('NetworkErrorを生成する', () => {
+      const error = createNetworkError('Connection timeout');
+      expect(error.type).toBe('network');
+      expect(error.message).toBe('Connection timeout');
+    });
+  });
+
+  describe('isDomainError', () => {
+    test('ApiErrorをDomainErrorと判定する', () => {
+      const error: ApiError = { type: 'api', status: 500, message: 'Error' };
+      expect(isDomainError(error)).toBe(true);
+    });
+
+    test('NetworkErrorをDomainErrorと判定する', () => {
+      const error: NetworkError = { type: 'network', message: 'Error' };
+      expect(isDomainError(error)).toBe(true);
+    });
+
+    test('nullはDomainErrorではない', () => {
+      expect(isDomainError(null)).toBe(false);
+    });
+
+    test('undefinedはDomainErrorではない', () => {
+      expect(isDomainError(undefined)).toBe(false);
+    });
+
+    test('通常のErrorはDomainErrorではない', () => {
+      expect(isDomainError(new Error('test'))).toBe(false);
+    });
+  });
+
+  describe('toDisplayError', () => {
+    test('ApiErrorを表示用文字列に変換', () => {
+      const error: ApiError = { type: 'api', status: 404, message: 'Not Found' };
+      expect(toDisplayError(error)).toBe('エラー (404): Not Found');
+    });
+
+    test('NetworkErrorを表示用文字列に変換', () => {
+      const error: NetworkError = { type: 'network', message: 'Connection failed' };
+      expect(toDisplayError(error)).toBe('ネットワークエラー: Connection failed');
+    });
+  });
+
+  describe('isUnauthorized', () => {
+    test('401 APIエラーをtrueと判定', () => {
+      const error: DomainError = { type: 'api', status: 401, message: 'Unauthorized' };
+      expect(isUnauthorized(error)).toBe(true);
+    });
+
+    test('他のステータスコードはfalse', () => {
+      const error: DomainError = { type: 'api', status: 403, message: 'Forbidden' };
+      expect(isUnauthorized(error)).toBe(false);
+    });
+
+    test('NetworkErrorはfalse', () => {
+      const error: DomainError = { type: 'network', message: 'Error' };
+      expect(isUnauthorized(error)).toBe(false);
+    });
+  });
+
+  describe('isForbidden', () => {
+    test('403 APIエラーをtrueと判定', () => {
+      const error: DomainError = { type: 'api', status: 403, message: 'Forbidden' };
+      expect(isForbidden(error)).toBe(true);
+    });
+
+    test('他のステータスコードはfalse', () => {
+      const error: DomainError = { type: 'api', status: 401, message: 'Unauthorized' };
+      expect(isForbidden(error)).toBe(false);
+    });
+
+    test('NetworkErrorはfalse', () => {
+      const error: DomainError = { type: 'network', message: 'Error' };
+      expect(isForbidden(error)).toBe(false);
+    });
+  });
+
+  describe('isConflict', () => {
+    test('409 APIエラーをtrueと判定', () => {
+      const error: DomainError = { type: 'api', status: 409, message: 'Conflict' };
+      expect(isConflict(error)).toBe(true);
+    });
+
+    test('他のステータスコードはfalse', () => {
+      const error: DomainError = { type: 'api', status: 400, message: 'Bad Request' };
+      expect(isConflict(error)).toBe(false);
+    });
+
+    test('NetworkErrorはfalse', () => {
+      const error: DomainError = { type: 'network', message: 'Error' };
+      expect(isConflict(error)).toBe(false);
+    });
+  });
+
+  describe('isServiceUnavailable', () => {
+    test('503 APIエラーをtrueと判定', () => {
+      const error: DomainError = { type: 'api', status: 503, message: 'Service Unavailable' };
+      expect(isServiceUnavailable(error)).toBe(true);
+    });
+
+    test('他のステータスコードはfalse', () => {
+      const error: DomainError = { type: 'api', status: 500, message: 'Internal Server Error' };
+      expect(isServiceUnavailable(error)).toBe(false);
+    });
+
+    test('NetworkErrorはfalse', () => {
+      const error: DomainError = { type: 'network', message: 'Error' };
+      expect(isServiceUnavailable(error)).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/infra/http/serverClient.test.ts
+++ b/src/__tests__/infra/http/serverClient.test.ts
@@ -1,4 +1,7 @@
-import { serverHttpClient } from '@/src/infra/http/serverClient';
+import {
+  parseErrorMessage,
+  serverHttpClient,
+} from '@/src/infra/http/serverClient';
 
 // fetchのモック
 const mockFetch = jest.fn();
@@ -15,6 +18,46 @@ describe('serverHttpClient', () => {
 
   afterEach(() => {
     process.env = originalEnv;
+  });
+
+  describe('parseErrorMessage', () => {
+    test('空文字列の場合はUnknown errorを返す', () => {
+      expect(parseErrorMessage('')).toBe('Unknown error');
+    });
+
+    test('{ errors: string[] }形式をカンマ区切りで結合', () => {
+      const json = JSON.stringify({ errors: ['Field required', 'Invalid format'] });
+      expect(parseErrorMessage(json)).toBe('Field required, Invalid format');
+    });
+
+    test('{ errors: [] }空配列の場合は元テキストを返す', () => {
+      const json = JSON.stringify({ errors: [] });
+      expect(parseErrorMessage(json)).toBe(json);
+    });
+
+    test('{ message: string }形式をパース', () => {
+      const json = JSON.stringify({ message: 'Something went wrong' });
+      expect(parseErrorMessage(json)).toBe('Something went wrong');
+    });
+
+    test('{ error: string }形式をパース', () => {
+      const json = JSON.stringify({ error: 'Not Found' });
+      expect(parseErrorMessage(json)).toBe('Not Found');
+    });
+
+    test('非JSON文字列はそのまま返す', () => {
+      expect(parseErrorMessage('Plain text error')).toBe('Plain text error');
+    });
+
+    test('認識できないJSON形式は元テキストを返す', () => {
+      const json = JSON.stringify({ status: 'failed', code: 500 });
+      expect(parseErrorMessage(json)).toBe(json);
+    });
+
+    test('errors配列内の単一要素を正しく処理', () => {
+      const json = JSON.stringify({ errors: ['Single error'] });
+      expect(parseErrorMessage(json)).toBe('Single error');
+    });
   });
 
   describe('get', () => {

--- a/src/__tests__/infra/http/serverClient.test.ts
+++ b/src/__tests__/infra/http/serverClient.test.ts
@@ -30,9 +30,9 @@ describe('serverHttpClient', () => {
       expect(parseErrorMessage(json)).toBe('Field required, Invalid format');
     });
 
-    test('{ errors: [] }空配列の場合は元テキストを返す', () => {
+    test('{ errors: [] }空配列の場合はUnknown errorを返す', () => {
       const json = JSON.stringify({ errors: [] });
-      expect(parseErrorMessage(json)).toBe(json);
+      expect(parseErrorMessage(json)).toBe('Unknown error');
     });
 
     test('{ message: string }形式をパース', () => {

--- a/src/__tests__/mutations/useCommentMutation.test.ts
+++ b/src/__tests__/mutations/useCommentMutation.test.ts
@@ -30,13 +30,12 @@ describe('useCommentMutation', () => {
 
       let response;
       await act(async () => {
-        response = await result.current.createComment('Test comment', 1, 100);
+        response = await result.current.createComment('Test comment', 100);
       });
 
       expect(response).toEqual({ success: true, data: mockComment });
       expect(mockHttpClient.post).toHaveBeenCalledWith('/api/comment', {
         content: 'Test comment',
-        accountId: 1,
         taskId: 100,
       });
     });
@@ -51,7 +50,7 @@ describe('useCommentMutation', () => {
 
       let response;
       await act(async () => {
-        response = await result.current.createComment('Test', 1, 100);
+        response = await result.current.createComment('Test', 100);
       });
 
       expect(response).toEqual({ success: false, error: 'Bad Request' });

--- a/src/__tests__/types/index.test.ts
+++ b/src/__tests__/types/index.test.ts
@@ -1,0 +1,87 @@
+import { isErrorResponse } from '@/src/types';
+
+describe('isErrorResponse', () => {
+  describe('正常なErrorResponseの判定', () => {
+    test('errors配列を持つオブジェクトはtrueを返す', () => {
+      expect(isErrorResponse({ errors: ['エラーメッセージ'] })).toBe(true);
+    });
+
+    test('複数のエラーメッセージを持つ場合もtrueを返す', () => {
+      expect(isErrorResponse({ errors: ['エラー1', 'エラー2', 'エラー3'] })).toBe(true);
+    });
+
+    test('空のerrors配列を持つオブジェクトはtrueを返す', () => {
+      expect(isErrorResponse({ errors: [] })).toBe(true);
+    });
+
+    test('追加のプロパティがあってもtrueを返す', () => {
+      expect(isErrorResponse({ errors: ['エラー'], extra: 'value' })).toBe(true);
+    });
+  });
+
+  describe('不正な値の判定', () => {
+    test('nullはfalseを返す', () => {
+      expect(isErrorResponse(null)).toBe(false);
+    });
+
+    test('undefinedはfalseを返す', () => {
+      expect(isErrorResponse(undefined)).toBe(false);
+    });
+
+    test('文字列はfalseを返す', () => {
+      expect(isErrorResponse('error')).toBe(false);
+    });
+
+    test('数値はfalseを返す', () => {
+      expect(isErrorResponse(123)).toBe(false);
+    });
+
+    test('配列はfalseを返す', () => {
+      expect(isErrorResponse(['error'])).toBe(false);
+    });
+
+    test('errorsプロパティがないオブジェクトはfalseを返す', () => {
+      expect(isErrorResponse({ message: 'error' })).toBe(false);
+    });
+
+    test('errorsが配列でないオブジェクトはfalseを返す', () => {
+      expect(isErrorResponse({ errors: 'not an array' })).toBe(false);
+    });
+
+    test('errorsがnullのオブジェクトはfalseを返す', () => {
+      expect(isErrorResponse({ errors: null })).toBe(false);
+    });
+  });
+
+  describe('配列要素の型検証', () => {
+    test('errors配列に数値が含まれる場合はfalseを返す', () => {
+      expect(isErrorResponse({ errors: [123] })).toBe(false);
+    });
+
+    test('errors配列にnullが含まれる場合はfalseを返す', () => {
+      expect(isErrorResponse({ errors: [null] })).toBe(false);
+    });
+
+    test('errors配列にundefinedが含まれる場合はfalseを返す', () => {
+      expect(isErrorResponse({ errors: [undefined] })).toBe(false);
+    });
+
+    test('errors配列にオブジェクトが含まれる場合はfalseを返す', () => {
+      expect(isErrorResponse({ errors: [{ message: 'error' }] })).toBe(false);
+    });
+
+    test('errors配列に混合型が含まれる場合はfalseを返す', () => {
+      expect(isErrorResponse({ errors: ['valid', 123, null] })).toBe(false);
+    });
+  });
+
+  describe('旧形式との互換性', () => {
+    test('旧形式のmessageのみのオブジェクトはfalseを返す', () => {
+      expect(isErrorResponse({ message: 'エラーメッセージ' })).toBe(false);
+    });
+
+    test('messageとerrorsの両方があればtrueを返す', () => {
+      expect(isErrorResponse({ message: 'エラー', errors: ['詳細'] })).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/util/auth-headers.test.ts
+++ b/src/__tests__/util/auth-headers.test.ts
@@ -9,6 +9,9 @@ jest.mock('next/headers', () => ({
 
 const mockCookies = cookies as jest.MockedFunction<typeof cookies>;
 
+// console.warnのモック
+const mockConsoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+
 describe('getAuthHeaders', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -37,7 +40,7 @@ describe('getAuthHeaders', () => {
   });
 
   describe('トークンが存在しない場合', () => {
-    test('cookieが取得できない場合は空オブジェクトを返す', () => {
+    test('cookieが取得できない場合は空オブジェクトを返し警告を出力', () => {
       mockCookies.mockReturnValue({
         get: jest.fn().mockReturnValue(undefined),
       } as unknown as ReturnType<typeof cookies>);
@@ -45,9 +48,12 @@ describe('getAuthHeaders', () => {
       const result = getAuthHeaders();
 
       expect(result).toEqual({});
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        '[getAuthHeaders] 認証トークンが見つかりません',
+      );
     });
 
-    test('cookieのvalueがundefinedの場合は空オブジェクトを返す', () => {
+    test('cookieのvalueがundefinedの場合は空オブジェクトを返し警告を出力', () => {
       mockCookies.mockReturnValue({
         get: jest.fn().mockReturnValue({ value: undefined }),
       } as unknown as ReturnType<typeof cookies>);
@@ -55,6 +61,9 @@ describe('getAuthHeaders', () => {
       const result = getAuthHeaders();
 
       expect(result).toEqual({});
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        '[getAuthHeaders] 認証トークンが見つかりません',
+      );
     });
   });
 
@@ -72,7 +81,7 @@ describe('getAuthHeaders', () => {
   });
 
   describe('空文字トークンの場合', () => {
-    test('空文字のトークンでもAuthorizationヘッダーを返す', () => {
+    test('空文字のトークンは空オブジェクトを返し警告を出力', () => {
       mockCookies.mockReturnValue({
         get: jest.fn().mockReturnValue({ value: '' }),
       } as unknown as ReturnType<typeof cookies>);
@@ -81,6 +90,21 @@ describe('getAuthHeaders', () => {
 
       // 空文字は falsy なので空オブジェクトを返す
       expect(result).toEqual({});
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        '[getAuthHeaders] 認証トークンが見つかりません',
+      );
+    });
+  });
+
+  describe('トークンが存在する場合の警告', () => {
+    test('トークンがある場合は警告を出力しない', () => {
+      mockCookies.mockReturnValue({
+        get: jest.fn().mockReturnValue({ value: 'valid-token' }),
+      } as unknown as ReturnType<typeof cookies>);
+
+      getAuthHeaders();
+
+      expect(mockConsoleWarn).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/util/auth-headers.test.ts
+++ b/src/__tests__/util/auth-headers.test.ts
@@ -1,0 +1,86 @@
+import { cookies } from 'next/headers';
+
+import { getAuthHeaders } from '@/src/util/auth-headers';
+
+// next/headersのcookies関数をモック
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+const mockCookies = cookies as jest.MockedFunction<typeof cookies>;
+
+describe('getAuthHeaders', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('トークンが存在する場合', () => {
+    test('Authorizationヘッダーを含むオブジェクトを返す', () => {
+      mockCookies.mockReturnValue({
+        get: jest.fn().mockReturnValue({ value: 'test-token-123' }),
+      } as unknown as ReturnType<typeof cookies>);
+
+      const result = getAuthHeaders();
+
+      expect(result).toEqual({ Authorization: 'Bearer test-token-123' });
+    });
+
+    test('Bearer形式でトークンが設定される', () => {
+      mockCookies.mockReturnValue({
+        get: jest.fn().mockReturnValue({ value: 'jwt-token-xyz' }),
+      } as unknown as ReturnType<typeof cookies>);
+
+      const result = getAuthHeaders();
+
+      expect(result.Authorization).toBe('Bearer jwt-token-xyz');
+    });
+  });
+
+  describe('トークンが存在しない場合', () => {
+    test('cookieが取得できない場合は空オブジェクトを返す', () => {
+      mockCookies.mockReturnValue({
+        get: jest.fn().mockReturnValue(undefined),
+      } as unknown as ReturnType<typeof cookies>);
+
+      const result = getAuthHeaders();
+
+      expect(result).toEqual({});
+    });
+
+    test('cookieのvalueがundefinedの場合は空オブジェクトを返す', () => {
+      mockCookies.mockReturnValue({
+        get: jest.fn().mockReturnValue({ value: undefined }),
+      } as unknown as ReturnType<typeof cookies>);
+
+      const result = getAuthHeaders();
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('cookies()の呼び出し', () => {
+    test('tokenという名前のcookieを取得する', () => {
+      const mockGet = jest.fn().mockReturnValue({ value: 'token-value' });
+      mockCookies.mockReturnValue({
+        get: mockGet,
+      } as unknown as ReturnType<typeof cookies>);
+
+      getAuthHeaders();
+
+      expect(mockGet).toHaveBeenCalledWith('token');
+    });
+  });
+
+  describe('空文字トークンの場合', () => {
+    test('空文字のトークンでもAuthorizationヘッダーを返す', () => {
+      mockCookies.mockReturnValue({
+        get: jest.fn().mockReturnValue({ value: '' }),
+      } as unknown as ReturnType<typeof cookies>);
+
+      const result = getAuthHeaders();
+
+      // 空文字は falsy なので空オブジェクトを返す
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/src/api/get-account-status.ts
+++ b/src/api/get-account-status.ts
@@ -20,7 +20,7 @@ export async function getAccountStatus(): Promise<ApiResult<MemberStatus[]>> {
   }
 
   const errorResponse: ErrorResponse = {
-    message: result.error.message,
+    errors: [result.error.message],
   };
   return errorResponse;
 }

--- a/src/api/get-account-status.ts
+++ b/src/api/get-account-status.ts
@@ -7,7 +7,7 @@ import { getCookies } from '@/src/util/cookies';
 export async function getAccountStatus(): Promise<ApiResult<MemberStatus[]>> {
   const token = getCookies('token');
   if (!token) {
-    return null;
+    return { errors: ['認証が必要です'] };
   }
 
   const result = await serverHttpClient.get<MemberStatus[]>('/accounts', {

--- a/src/api/get-account-tasks.ts
+++ b/src/api/get-account-tasks.ts
@@ -2,10 +2,13 @@
 
 import { serverHttpClient } from '@/src/infra/http';
 import { Task } from '@/src/types';
+import { getCookies } from '@/src/util/cookies';
 
 export const getAccountTasks = async (id: string): Promise<Task[]> => {
+  const token = getCookies('token');
   const result = await serverHttpClient.get<Task[]>(`/account/tasks?id=${id}`, {
     cache: 'no-store',
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
   });
 
   if (result.ok) {

--- a/src/api/get-account-tasks.ts
+++ b/src/api/get-account-tasks.ts
@@ -1,10 +1,12 @@
 'use server';
 
 import { serverHttpClient } from '@/src/infra/http';
-import { Task } from '@/src/types';
+import { ErrorResponse, Task } from '@/src/types';
 import { getCookies } from '@/src/util/cookies';
 
-export const getAccountTasks = async (id: string): Promise<Task[]> => {
+export const getAccountTasks = async (
+  id: string,
+): Promise<Task[] | ErrorResponse> => {
   const token = getCookies('token');
   const result = await serverHttpClient.get<Task[]>(`/account/tasks?id=${id}`, {
     cache: 'no-store',
@@ -15,5 +17,5 @@ export const getAccountTasks = async (id: string): Promise<Task[]> => {
     return result.value;
   }
   console.error('Failed to fetch account tasks:', result.error.message);
-  return [];
+  return { errors: [result.error.message] };
 };

--- a/src/api/get-areas.ts
+++ b/src/api/get-areas.ts
@@ -1,10 +1,10 @@
 'use server';
 
 import { serverHttpClient } from '@/src/infra/http';
-import { Area } from '@/src/types';
+import { Area, ErrorResponse } from '@/src/types';
 import { getCookies } from '@/src/util/cookies';
 
-export const getAreas = async (): Promise<Area[]> => {
+export const getAreas = async (): Promise<Area[] | ErrorResponse> => {
   const token = getCookies('token');
   const result = await serverHttpClient.get<Area[]>('/areas', {
     headers: token ? { Authorization: `Bearer ${token}` } : undefined,
@@ -13,5 +13,6 @@ export const getAreas = async (): Promise<Area[]> => {
   if (result.ok) {
     return result.value;
   }
-  return [];
+  console.error('Failed to fetch areas:', result.error.message);
+  return { errors: [result.error.message] };
 };

--- a/src/api/get-areas.ts
+++ b/src/api/get-areas.ts
@@ -2,9 +2,13 @@
 
 import { serverHttpClient } from '@/src/infra/http';
 import { Area } from '@/src/types';
+import { getCookies } from '@/src/util/cookies';
 
 export const getAreas = async (): Promise<Area[]> => {
-  const result = await serverHttpClient.get<Area[]>('/areas');
+  const token = getCookies('token');
+  const result = await serverHttpClient.get<Area[]>('/areas', {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
 
   if (result.ok) {
     return result.value;

--- a/src/api/get-tasks.ts
+++ b/src/api/get-tasks.ts
@@ -2,10 +2,13 @@
 
 import { serverHttpClient } from '@/src/infra/http';
 import { Task } from '@/src/types';
+import { getCookies } from '@/src/util/cookies';
 
 export async function getTasks(): Promise<Task[]> {
+  const token = getCookies('token');
   const result = await serverHttpClient.get<Task[]>('/tasks?type=all', {
     cache: 'no-store',
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
   });
 
   if (result.ok) {

--- a/src/api/get-tasks.ts
+++ b/src/api/get-tasks.ts
@@ -1,10 +1,10 @@
 'use server';
 
 import { serverHttpClient } from '@/src/infra/http';
-import { Task } from '@/src/types';
+import { ErrorResponse, Task } from '@/src/types';
 import { getCookies } from '@/src/util/cookies';
 
-export async function getTasks(): Promise<Task[]> {
+export async function getTasks(): Promise<Task[] | ErrorResponse> {
   const token = getCookies('token');
   const result = await serverHttpClient.get<Task[]>('/tasks?type=all', {
     cache: 'no-store',
@@ -14,5 +14,6 @@ export async function getTasks(): Promise<Task[]> {
   if (result.ok) {
     return result.value;
   }
-  return [];
+  console.error('Failed to fetch tasks:', result.error.message);
+  return { errors: [result.error.message] };
 }

--- a/src/api/get-unfulfilled-count.ts
+++ b/src/api/get-unfulfilled-count.ts
@@ -2,10 +2,13 @@
 
 import { serverHttpClient } from '@/src/infra/http';
 import { ApiResult, ErrorResponse } from '@/src/types';
+import { getCookies } from '@/src/util/cookies';
 
 export async function getUnfulfilledCount(): Promise<ApiResult<number>> {
+  const token = getCookies('token');
   const result = await serverHttpClient.get<number>('/unfulfilled-count', {
     revalidate: 60, // 1分ごとに再検証
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
   });
 
   if (result.ok) {
@@ -13,7 +16,7 @@ export async function getUnfulfilledCount(): Promise<ApiResult<number>> {
   }
 
   const errorResponse: ErrorResponse = {
-    message: result.error.message,
+    errors: [result.error.message],
   };
   return errorResponse;
 }

--- a/src/api/get-week-complete.ts
+++ b/src/api/get-week-complete.ts
@@ -2,10 +2,13 @@
 
 import { serverHttpClient } from '@/src/infra/http';
 import { WeekCompleteData, ApiResult, ErrorResponse } from '@/src/types';
+import { getCookies } from '@/src/util/cookies';
 
 export async function getWeekComplete(): Promise<ApiResult<WeekCompleteData>> {
+  const token = getCookies('token');
   const result = await serverHttpClient.get<WeekCompleteData>('/completed-data', {
     revalidate: 300, // 5分ごとに再検証
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
   });
 
   if (result.ok) {
@@ -13,7 +16,7 @@ export async function getWeekComplete(): Promise<ApiResult<WeekCompleteData>> {
   }
 
   const errorResponse: ErrorResponse = {
-    message: result.error.message,
+    errors: [result.error.message],
   };
   return errorResponse;
 }

--- a/src/api/post-task-create.ts
+++ b/src/api/post-task-create.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { serverHttpClient } from '@/src/infra/http';
+import { ErrorResponse } from '@/src/types';
 import { getCookies } from '@/src/util/cookies';
 
 type TaskResponse = {
@@ -9,7 +10,7 @@ type TaskResponse = {
 
 const postTaskCreate = async (
   name: string,
-): Promise<TaskResponse | Record<string, never>> => {
+): Promise<TaskResponse | ErrorResponse> => {
   const token = getCookies('token');
   const result = await serverHttpClient.post<TaskResponse>(
     '/tasks',
@@ -24,7 +25,7 @@ const postTaskCreate = async (
     return result.value;
   }
   console.error('Task creation failed:', result.error.message);
-  return {};
+  return { errors: [result.error.message] };
 };
 
 export default postTaskCreate;

--- a/src/api/post-task-create.ts
+++ b/src/api/post-task-create.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { serverHttpClient } from '@/src/infra/http';
+import { getCookies } from '@/src/util/cookies';
 
 type TaskResponse = {
   [key: string]: string;
@@ -9,10 +10,14 @@ type TaskResponse = {
 const postTaskCreate = async (
   name: string,
 ): Promise<TaskResponse | Record<string, never>> => {
+  const token = getCookies('token');
   const result = await serverHttpClient.post<TaskResponse>(
     '/tasks',
     { task: { task_title: name } },
-    { cache: 'no-store' },
+    {
+      cache: 'no-store',
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    },
   );
 
   if (result.ok) {

--- a/src/app/(admin)/dashboard/page.tsx
+++ b/src/app/(admin)/dashboard/page.tsx
@@ -11,9 +11,13 @@ import UploadButton from '@/src/components/Buttons/UploadButton';
 import Chart from '@/src/components/Chart';
 import Orders from '@/src/components/Orders';
 import Uncompletes from '@/src/components/Uncompletes';
+import { isErrorResponse } from '@/src/types';
 
 const Dashboard = async () => {
-  const areaNames: string[] = (await getAreas()).map((area) => area.name);
+  const areasResult = await getAreas();
+  const areaNames: string[] = isErrorResponse(areasResult)
+    ? []
+    : areasResult.map((area) => area.name);
   // const areaNames: string[] = areas?.map((area) => area.name);
   return (
     <Box sx={{ display: 'flex', flexGrow: 1 }}>

--- a/src/app/api/account/[id]/route.ts
+++ b/src/app/api/account/[id]/route.ts
@@ -1,17 +1,9 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import { ResponseStatus } from '@/src/types';
-
-/**
- * 認証ヘッダーを取得
- */
-const getAuthHeader = (): Record<string, string> => {
-  const token = cookies().get('token')?.value;
-  return token ? { Authorization: `Bearer ${token}` } : {};
-};
+import { getAuthHeaders } from '@/src/util/auth-headers';
 
 export const DELETE = async (
   request: Request,
@@ -23,7 +15,7 @@ export const DELETE = async (
     const res = await fetch(`${process.env.API_HOST}/accounts/${id}`, {
       method: 'DELETE',
       headers: {
-        ...getAuthHeader(),
+        ...getAuthHeaders(),
       },
     });
 

--- a/src/app/api/account/[id]/route.ts
+++ b/src/app/api/account/[id]/route.ts
@@ -1,8 +1,17 @@
 'use server';
 
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import { ResponseStatus } from '@/src/types';
+
+/**
+ * 認証ヘッダーを取得
+ */
+const getAuthHeader = (): Record<string, string> => {
+  const token = cookies().get('token')?.value;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
 
 export const DELETE = async (
   request: Request,
@@ -13,11 +22,20 @@ export const DELETE = async (
   try {
     const res = await fetch(`${process.env.API_HOST}/accounts/${id}`, {
       method: 'DELETE',
+      headers: {
+        ...getAuthHeader(),
+      },
     });
-    const result: ResponseStatus = (await res.json()) as ResponseStatus;
-    return NextResponse.json(result);
+
+    if (res.ok) {
+      const result: ResponseStatus = (await res.json()) as ResponseStatus;
+      return NextResponse.json(result);
+    } else {
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+    }
   } catch (err) {
     console.error(err);
-    return NextResponse.json({});
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/account/[id]/route.ts
+++ b/src/app/api/account/[id]/route.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse } from 'next/server';
 
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { ResponseStatus } from '@/src/types';
 import { getAuthHeaders } from '@/src/util/auth-headers';
 
@@ -10,6 +11,13 @@ export const DELETE = async (
   { params }: { params: { id: string } },
 ) => {
   const id = params.id;
+
+  if (!id || id.trim() === '') {
+    return NextResponse.json(
+      { errors: ['IDが不正または未指定です'] },
+      { status: 400 },
+    );
+  }
 
   try {
     const res = await fetch(`${process.env.API_HOST}/accounts/${id}`, {
@@ -24,10 +32,11 @@ export const DELETE = async (
       return NextResponse.json(result);
     } else {
       const errorText = await res.text().catch(() => '');
-      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
     }
   } catch (err) {
-    console.error(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[DELETE] /api/account/[id]:', errorMessage);
     return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/account/[id]/tasks/route.ts
+++ b/src/app/api/account/[id]/tasks/route.ts
@@ -1,9 +1,17 @@
 'use server';
 
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
-import { getAccountTasks } from '@/src/api/get-account-tasks';
 import { Task } from '@/src/types';
+
+/**
+ * 認証ヘッダーを取得
+ */
+const getAuthHeader = (): Record<string, string> => {
+  const token = cookies().get('token')?.value;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
 
 export const GET = async (
   request: Request,
@@ -12,10 +20,22 @@ export const GET = async (
   const id = params.id;
 
   try {
-    const res: Task[] = await getAccountTasks(id);
-    return NextResponse.json(res);
+    const res = await fetch(`${process.env.API_HOST}/account/tasks?id=${id}`, {
+      cache: 'no-store',
+      headers: {
+        ...getAuthHeader(),
+      },
+    });
+
+    if (res.ok) {
+      const result: Task[] = (await res.json()) as Task[];
+      return NextResponse.json(result);
+    } else {
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+    }
   } catch (err) {
     console.error(err);
-    return NextResponse.json(Array<Task>);
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/account/[id]/tasks/route.ts
+++ b/src/app/api/account/[id]/tasks/route.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse } from 'next/server';
 
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { Task } from '@/src/types';
 import { getAuthHeaders } from '@/src/util/auth-headers';
 
@@ -10,6 +11,13 @@ export const GET = async (
   { params }: { params: { id: string } },
 ) => {
   const id = params.id;
+
+  if (!id || id.trim() === '') {
+    return NextResponse.json(
+      { errors: ['IDが不正または未指定です'] },
+      { status: 400 },
+    );
+  }
 
   try {
     const res = await fetch(`${process.env.API_HOST}/account/tasks?id=${id}`, {
@@ -24,10 +32,11 @@ export const GET = async (
       return NextResponse.json(result);
     } else {
       const errorText = await res.text().catch(() => '');
-      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
     }
   } catch (err) {
-    console.error(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[GET] /api/account/[id]/tasks:', errorMessage);
     return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/account/[id]/tasks/route.ts
+++ b/src/app/api/account/[id]/tasks/route.ts
@@ -1,17 +1,9 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import { Task } from '@/src/types';
-
-/**
- * 認証ヘッダーを取得
- */
-const getAuthHeader = (): Record<string, string> => {
-  const token = cookies().get('token')?.value;
-  return token ? { Authorization: `Bearer ${token}` } : {};
-};
+import { getAuthHeaders } from '@/src/util/auth-headers';
 
 export const GET = async (
   request: Request,
@@ -23,7 +15,7 @@ export const GET = async (
     const res = await fetch(`${process.env.API_HOST}/account/tasks?id=${id}`, {
       cache: 'no-store',
       headers: {
-        ...getAuthHeader(),
+        ...getAuthHeaders(),
       },
     });
 

--- a/src/app/api/areas/route.ts
+++ b/src/app/api/areas/route.ts
@@ -1,24 +1,16 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import { Area } from '@/src/types';
-
-/**
- * 認証ヘッダーを取得
- */
-const getAuthHeader = (): Record<string, string> => {
-  const token = cookies().get('token')?.value;
-  return token ? { Authorization: `Bearer ${token}` } : {};
-};
+import { getAuthHeaders } from '@/src/util/auth-headers';
 
 export const GET = async () => {
   try {
     const res = await fetch(`${process.env.API_HOST}/areas`, {
       method: 'GET',
       headers: {
-        ...getAuthHeader(),
+        ...getAuthHeaders(),
       },
     });
     if (res.ok) {

--- a/src/app/api/areas/route.ts
+++ b/src/app/api/areas/route.ts
@@ -1,22 +1,35 @@
 'use server';
 
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import { Area } from '@/src/types';
+
+/**
+ * 認証ヘッダーを取得
+ */
+const getAuthHeader = (): Record<string, string> => {
+  const token = cookies().get('token')?.value;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
 
 export const GET = async () => {
   try {
     const res = await fetch(`${process.env.API_HOST}/areas`, {
       method: 'GET',
+      headers: {
+        ...getAuthHeader(),
+      },
     });
     if (res.ok) {
       const result: Area[] = (await res.json()) as Area[];
       return NextResponse.json(result);
     } else {
-      return NextResponse.json({});
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
     }
   } catch (err) {
     console.error(err);
-    return NextResponse.json({});
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/areas/route.ts
+++ b/src/app/api/areas/route.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse } from 'next/server';
 
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { Area } from '@/src/types';
 import { getAuthHeaders } from '@/src/util/auth-headers';
 
@@ -18,10 +19,11 @@ export const GET = async () => {
       return NextResponse.json(result);
     } else {
       const errorText = await res.text().catch(() => '');
-      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
     }
   } catch (err) {
-    console.error(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[GET] /api/areas:', errorMessage);
     return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/aws/route.ts
+++ b/src/app/api/aws/route.ts
@@ -12,6 +12,7 @@ import { NextResponse } from 'next/server';
 import { type NextRequest } from 'next/server';
 
 import postTaskCreate from '@/src/api/post-task-create';
+import { isErrorResponse } from '@/src/types';
 
 // 定数定義
 const ALLOWED_FILE_TYPES = ['application/pdf', 'image/jpeg', 'image/png'];
@@ -107,7 +108,11 @@ export const POST = async (request: Request) => {
     await s3Client.send(command);
 
     // タスク作成
-    await postTaskCreate(name);
+    const taskResult = await postTaskCreate(name);
+    if (isErrorResponse(taskResult)) {
+      console.error('Task creation failed:', taskResult.errors);
+      // タスク作成失敗してもファイルアップロードは成功しているので続行
+    }
 
     // 署名付きURLを生成してアクセス可能にする
     const getCommand = new GetObjectCommand({

--- a/src/app/api/aws/route.ts
+++ b/src/app/api/aws/route.ts
@@ -39,7 +39,7 @@ export const GET = async (request: NextRequest) => {
   // キーのバリデーション
   if (!key || typeof key !== 'string' || key.trim() === '') {
     return NextResponse.json(
-      { error: 'Invalid or missing key parameter' },
+      { errors: ['Invalid or missing key parameter'] },
       { status: 400 }
     );
   }
@@ -57,7 +57,7 @@ export const GET = async (request: NextRequest) => {
   } catch (err) {
     console.error('Failed to generate signed URL:', err);
     return NextResponse.json(
-      { error: 'Failed to generate signed URL' },
+      { errors: ['Failed to generate signed URL'] },
       { status: 500 }
     );
   }
@@ -71,7 +71,7 @@ export const POST = async (request: Request) => {
     // ファイルの存在チェック
     if (!file) {
       return NextResponse.json(
-        { error: 'No file provided' },
+        { errors: ['No file provided'] },
         { status: 400 }
       );
     }
@@ -79,7 +79,7 @@ export const POST = async (request: Request) => {
     // ファイルサイズのバリデーション
     if (file.size > MAX_FILE_SIZE) {
       return NextResponse.json(
-        { error: `File size exceeds limit of ${MAX_FILE_SIZE / (1024 * 1024)}MB` },
+        { errors: [`File size exceeds limit of ${MAX_FILE_SIZE / (1024 * 1024)}MB`] },
         { status: 400 }
       );
     }
@@ -87,7 +87,7 @@ export const POST = async (request: Request) => {
     // ファイルタイプのバリデーション
     if (!ALLOWED_FILE_TYPES.includes(file.type)) {
       return NextResponse.json(
-        { error: `File type ${file.type} is not allowed. Allowed types: ${ALLOWED_FILE_TYPES.join(', ')}` },
+        { errors: [`File type ${file.type} is not allowed. Allowed types: ${ALLOWED_FILE_TYPES.join(', ')}`] },
         { status: 400 }
       );
     }
@@ -111,7 +111,10 @@ export const POST = async (request: Request) => {
     const taskResult = await postTaskCreate(name);
     if (isErrorResponse(taskResult)) {
       console.error('Task creation failed:', taskResult.errors);
-      // タスク作成失敗してもファイルアップロードは成功しているので続行
+      return NextResponse.json(
+        { errors: ['ファイルのアップロードは成功しましたが、タスクの作成に失敗しました'] },
+        { status: 500 }
+      );
     }
 
     // 署名付きURLを生成してアクセス可能にする
@@ -125,7 +128,7 @@ export const POST = async (request: Request) => {
   } catch (err) {
     console.error('Upload failed:', err);
     return NextResponse.json(
-      { error: 'Failed to upload file' },
+      { errors: ['Failed to upload file'] },
       { status: 500 }
     );
   }

--- a/src/app/api/comment/route.ts
+++ b/src/app/api/comment/route.ts
@@ -12,7 +12,16 @@ type Body = {
 };
 
 export const POST = async (request: NextRequest) => {
-  const body: Body = (await request.json()) as Body;
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json(
+      { errors: ['リクエストボディのJSON形式が不正です'] },
+      { status: 400 },
+    );
+  }
+
   try {
     const res = await fetch(`${process.env.API_HOST}/comments`, {
       method: 'POST',
@@ -42,7 +51,16 @@ export const POST = async (request: NextRequest) => {
 };
 
 export const PUT = async (request: NextRequest) => {
-  const body: Body = (await request.json()) as Body;
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json(
+      { errors: ['リクエストボディのJSON形式が不正です'] },
+      { status: 400 },
+    );
+  }
+
   try {
     const res = await fetch(`${process.env.API_HOST}/comments/${body.id}`, {
       method: 'PUT',
@@ -74,6 +92,13 @@ export const PUT = async (request: NextRequest) => {
 export const DELETE = async (request: NextRequest) => {
   const searchParams = request.nextUrl.searchParams;
   const commentId = searchParams.get('commentId');
+
+  if (!commentId || isNaN(Number(commentId))) {
+    return NextResponse.json(
+      { errors: ['commentIdが不正または未指定です'] },
+      { status: 400 },
+    );
+  }
 
   try {
     const res = await fetch(`${process.env.API_HOST}/comments/${commentId}`, {

--- a/src/app/api/comment/route.ts
+++ b/src/app/api/comment/route.ts
@@ -1,22 +1,14 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { Comment, CommentApiResponse } from '@/src/types';
+import { getAuthHeaders } from '@/src/util/auth-headers';
 
 type Body = {
   id: number;
   content: string;
   taskId: number;
-};
-
-/**
- * 認証ヘッダーを取得
- */
-const getAuthHeader = (): Record<string, string> => {
-  const token = cookies().get('token')?.value;
-  return token ? { Authorization: `Bearer ${token}` } : {};
 };
 
 export const POST = async (request: NextRequest) => {
@@ -27,7 +19,7 @@ export const POST = async (request: NextRequest) => {
       cache: 'no-store',
       headers: {
         'Content-Type': 'application/json',
-        ...getAuthHeader(),
+        ...getAuthHeaders(),
       },
       body: JSON.stringify({
         comment: {
@@ -57,7 +49,7 @@ export const PUT = async (request: NextRequest) => {
       cache: 'no-store',
       headers: {
         'Content-Type': 'application/json',
-        ...getAuthHeader(),
+        ...getAuthHeaders(),
       },
       body: JSON.stringify({
         comment: {
@@ -88,7 +80,7 @@ export const DELETE = async (request: NextRequest) => {
       method: 'DELETE',
       cache: 'no-store',
       headers: {
-        ...getAuthHeader(),
+        ...getAuthHeaders(),
       },
     });
 

--- a/src/app/api/comment/route.ts
+++ b/src/app/api/comment/route.ts
@@ -2,6 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { Comment, CommentApiResponse } from '@/src/types';
 import { getAuthHeaders } from '@/src/util/auth-headers';
 
@@ -42,10 +43,11 @@ export const POST = async (request: NextRequest) => {
       return NextResponse.json(result);
     } else {
       const errorText = await res.text().catch(() => '');
-      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
     }
   } catch (err) {
-    console.error(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[POST] /api/comment:', errorMessage);
     return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };
@@ -81,10 +83,11 @@ export const PUT = async (request: NextRequest) => {
       return NextResponse.json(result);
     } else {
       const errorText = await res.text().catch(() => '');
-      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
     }
   } catch (err) {
-    console.error(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[PUT] /api/comment:', errorMessage);
     return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };
@@ -114,10 +117,11 @@ export const DELETE = async (request: NextRequest) => {
       return NextResponse.json(result);
     } else {
       const errorText = await res.text().catch(() => '');
-      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
     }
   } catch (err) {
-    console.error(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[DELETE] /api/comment:', errorMessage);
     return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/comment/route.ts
+++ b/src/app/api/comment/route.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { Comment, CommentApiResponse } from '@/src/types';
@@ -7,8 +8,15 @@ import { Comment, CommentApiResponse } from '@/src/types';
 type Body = {
   id: number;
   content: string;
-  accountId: number;
   taskId: number;
+};
+
+/**
+ * 認証ヘッダーを取得
+ */
+const getAuthHeader = (): Record<string, string> => {
+  const token = cookies().get('token')?.value;
+  return token ? { Authorization: `Bearer ${token}` } : {};
 };
 
 export const POST = async (request: NextRequest) => {
@@ -19,11 +27,11 @@ export const POST = async (request: NextRequest) => {
       cache: 'no-store',
       headers: {
         'Content-Type': 'application/json',
+        ...getAuthHeader(),
       },
       body: JSON.stringify({
         comment: {
           content: body.content,
-          account_id: body.accountId,
           task_id: body.taskId,
         },
       }),
@@ -32,11 +40,12 @@ export const POST = async (request: NextRequest) => {
       const result: Comment = (await res.json()) as Comment;
       return NextResponse.json(result);
     } else {
-      return NextResponse.json({});
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
     }
   } catch (err) {
     console.error(err);
-    return NextResponse.json({});
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };
 
@@ -48,6 +57,7 @@ export const PUT = async (request: NextRequest) => {
       cache: 'no-store',
       headers: {
         'Content-Type': 'application/json',
+        ...getAuthHeader(),
       },
       body: JSON.stringify({
         comment: {
@@ -60,11 +70,12 @@ export const PUT = async (request: NextRequest) => {
       const result: Comment = (await res.json()) as Comment;
       return NextResponse.json(result);
     } else {
-      return NextResponse.json({});
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
     }
   } catch (err) {
     console.error(err);
-    return NextResponse.json({});
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };
 
@@ -76,16 +87,20 @@ export const DELETE = async (request: NextRequest) => {
     const res = await fetch(`${process.env.API_HOST}/comments/${commentId}`, {
       method: 'DELETE',
       cache: 'no-store',
+      headers: {
+        ...getAuthHeader(),
+      },
     });
 
     if (res.ok) {
       const result: CommentApiResponse = (await res.json()) as CommentApiResponse;
       return NextResponse.json(result);
     } else {
-      return NextResponse.json({});
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
     }
   } catch (err) {
     console.error(err);
-    return NextResponse.json({});
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -2,6 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { Comment } from '@/src/types';
 import { getAuthHeaders } from '@/src/util/auth-headers';
 
@@ -25,10 +26,11 @@ export const GET = async (request: NextRequest) => {
       return NextResponse.json(result);
     } else {
       const errorText = await res.text().catch(() => '');
-      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
     }
   } catch (err) {
-    console.error(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[GET] /api/comments:', errorMessage);
     return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -10,6 +10,22 @@ export const GET = async (request: NextRequest) => {
   const searchParams = request.nextUrl.searchParams;
   const taskId = searchParams.get('taskId');
   const accountId = searchParams.get('accountId');
+
+  // 入力バリデーション
+  if (!taskId || !accountId) {
+    return NextResponse.json(
+      { errors: ['taskIdとaccountIdは必須です'] },
+      { status: 400 },
+    );
+  }
+
+  if (isNaN(Number(taskId)) || isNaN(Number(accountId))) {
+    return NextResponse.json(
+      { errors: ['taskIdとaccountIdは数値である必要があります'] },
+      { status: 400 },
+    );
+  }
+
   try {
     const res = await fetch(
       `${process.env.API_HOST}/comments?taskId=${taskId}&accountId=${accountId}`,

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,17 +1,9 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { Comment } from '@/src/types';
-
-/**
- * 認証ヘッダーを取得
- */
-const getAuthHeader = (): Record<string, string> => {
-  const token = cookies().get('token')?.value;
-  return token ? { Authorization: `Bearer ${token}` } : {};
-};
+import { getAuthHeaders } from '@/src/util/auth-headers';
 
 export const GET = async (request: NextRequest) => {
   const searchParams = request.nextUrl.searchParams;
@@ -23,7 +15,7 @@ export const GET = async (request: NextRequest) => {
       {
         cache: 'no-store',
         headers: {
-          ...getAuthHeader(),
+          ...getAuthHeaders(),
         },
       },
     );

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,8 +1,17 @@
 'use server';
 
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { Comment } from '@/src/types';
+
+/**
+ * 認証ヘッダーを取得
+ */
+const getAuthHeader = (): Record<string, string> => {
+  const token = cookies().get('token')?.value;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
 
 export const GET = async (request: NextRequest) => {
   const searchParams = request.nextUrl.searchParams;
@@ -13,6 +22,9 @@ export const GET = async (request: NextRequest) => {
       `${process.env.API_HOST}/comments?taskId=${taskId}&accountId=${accountId}`,
       {
         cache: 'no-store',
+        headers: {
+          ...getAuthHeader(),
+        },
       },
     );
 
@@ -20,10 +32,11 @@ export const GET = async (request: NextRequest) => {
       const result: Comment[] = (await res.json()) as Comment[];
       return NextResponse.json(result);
     } else {
-      return NextResponse.json({});
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
     }
   } catch (err) {
     console.error(err);
-    return NextResponse.json({});
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/task/[id]/complete/route.ts
+++ b/src/app/api/task/[id]/complete/route.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse } from 'next/server';
 
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { getAuthHeaders } from '@/src/util/auth-headers';
 
 type Result = {
@@ -14,6 +15,14 @@ export const PUT = async (
   { params }: { params: { id: string } },
 ) => {
   const id: string = params.id;
+
+  if (!id || id.trim() === '') {
+    return NextResponse.json(
+      { errors: ['IDが不正または未指定です'] },
+      { status: 400 },
+    );
+  }
+
   try {
     const res = await fetch(`${process.env.API_HOST}/tasks/${id}/completed`, {
       method: 'PUT',
@@ -28,10 +37,11 @@ export const PUT = async (
       return NextResponse.json(result);
     } else {
       const errorText = await res.text().catch(() => '');
-      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
     }
   } catch (err) {
-    console.error(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[PUT] /api/task/[id]/complete:', errorMessage);
     return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/task/[id]/complete/route.ts
+++ b/src/app/api/task/[id]/complete/route.ts
@@ -1,10 +1,19 @@
 'use server';
 
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 type Result = {
   message: string;
   result: boolean;
+};
+
+/**
+ * 認証ヘッダーを取得
+ */
+const getAuthHeader = (): Record<string, string> => {
+  const token = cookies().get('token')?.value;
+  return token ? { Authorization: `Bearer ${token}` } : {};
 };
 
 export const PUT = async (
@@ -16,16 +25,20 @@ export const PUT = async (
     const res = await fetch(`${process.env.API_HOST}/tasks/${id}/completed`, {
       method: 'PUT',
       cache: 'no-store',
+      headers: {
+        ...getAuthHeader(),
+      },
     });
 
     if (res.ok) {
       const result: Result = (await res.json()) as Result;
       return NextResponse.json(result);
     } else {
-      return NextResponse.json({});
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
     }
   } catch (err) {
     console.error(err);
-    return NextResponse.json({});
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/task/[id]/complete/route.ts
+++ b/src/app/api/task/[id]/complete/route.ts
@@ -1,19 +1,12 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+
+import { getAuthHeaders } from '@/src/util/auth-headers';
 
 type Result = {
   message: string;
   result: boolean;
-};
-
-/**
- * 認証ヘッダーを取得
- */
-const getAuthHeader = (): Record<string, string> => {
-  const token = cookies().get('token')?.value;
-  return token ? { Authorization: `Bearer ${token}` } : {};
 };
 
 export const PUT = async (
@@ -26,7 +19,7 @@ export const PUT = async (
       method: 'PUT',
       cache: 'no-store',
       headers: {
-        ...getAuthHeader(),
+        ...getAuthHeaders(),
       },
     });
 

--- a/src/app/api/task/[id]/ng/route.ts
+++ b/src/app/api/task/[id]/ng/route.ts
@@ -1,19 +1,12 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+
+import { getAuthHeaders } from '@/src/util/auth-headers';
 
 type Result = {
   message: string;
   result: boolean;
-};
-
-/**
- * 認証ヘッダーを取得
- */
-const getAuthHeader = (): Record<string, string> => {
-  const token = cookies().get('token')?.value;
-  return token ? { Authorization: `Bearer ${token}` } : {};
 };
 
 export const PUT = async (
@@ -26,7 +19,7 @@ export const PUT = async (
       method: 'PUT',
       cache: 'no-store',
       headers: {
-        ...getAuthHeader(),
+        ...getAuthHeaders(),
       },
     });
 

--- a/src/app/api/task/[id]/ng/route.ts
+++ b/src/app/api/task/[id]/ng/route.ts
@@ -1,10 +1,19 @@
 'use server';
 
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 type Result = {
   message: string;
   result: boolean;
+};
+
+/**
+ * 認証ヘッダーを取得
+ */
+const getAuthHeader = (): Record<string, string> => {
+  const token = cookies().get('token')?.value;
+  return token ? { Authorization: `Bearer ${token}` } : {};
 };
 
 export const PUT = async (
@@ -16,16 +25,20 @@ export const PUT = async (
     const res = await fetch(`${process.env.API_HOST}/tasks/${id}/ng`, {
       method: 'PUT',
       cache: 'no-store',
+      headers: {
+        ...getAuthHeader(),
+      },
     });
 
     if (res.ok) {
       const result: Result = (await res.json()) as Result;
       return NextResponse.json(result);
     } else {
-      return NextResponse.json({});
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
     }
   } catch (err) {
     console.error(err);
-    return NextResponse.json({});
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/task/[id]/ng/route.ts
+++ b/src/app/api/task/[id]/ng/route.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse } from 'next/server';
 
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { getAuthHeaders } from '@/src/util/auth-headers';
 
 type Result = {
@@ -14,6 +15,14 @@ export const PUT = async (
   { params }: { params: { id: string } },
 ) => {
   const id: string = params.id;
+
+  if (!id || id.trim() === '') {
+    return NextResponse.json(
+      { errors: ['IDが不正または未指定です'] },
+      { status: 400 },
+    );
+  }
+
   try {
     const res = await fetch(`${process.env.API_HOST}/tasks/${id}/ng`, {
       method: 'PUT',
@@ -28,10 +37,11 @@ export const PUT = async (
       return NextResponse.json(result);
     } else {
       const errorText = await res.text().catch(() => '');
-      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
     }
   } catch (err) {
-    console.error(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[PUT] /api/task/[id]/ng:', errorMessage);
     return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/task/[id]/reassign/route.ts
+++ b/src/app/api/task/[id]/reassign/route.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse } from 'next/server';
 
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { getAuthHeaders } from '@/src/util/auth-headers';
 
 export type Task = {
@@ -13,6 +14,14 @@ export const PUT = async (
   { params }: { params: { id: string } },
 ) => {
   const id: string = params.id;
+
+  if (!id || id.trim() === '') {
+    return NextResponse.json(
+      { errors: ['IDが不正または未指定です'] },
+      { status: 400 },
+    );
+  }
+
   try {
     const res = await fetch(`${process.env.API_HOST}/tasks/${id}/newCycle`, {
       method: 'POST',
@@ -27,10 +36,11 @@ export const PUT = async (
       return NextResponse.json(result);
     } else {
       const errorText = await res.text().catch(() => '');
-      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
     }
   } catch (err) {
-    console.error(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[PUT] /api/task/[id]/reassign:', errorMessage);
     return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/task/[id]/reassign/route.ts
+++ b/src/app/api/task/[id]/reassign/route.ts
@@ -1,9 +1,18 @@
 'use server';
 
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 export type Task = {
   [key: string]: string | number;
+};
+
+/**
+ * 認証ヘッダーを取得
+ */
+const getAuthHeader = (): Record<string, string> => {
+  const token = cookies().get('token')?.value;
+  return token ? { Authorization: `Bearer ${token}` } : {};
 };
 
 export const PUT = async (
@@ -15,16 +24,20 @@ export const PUT = async (
     const res = await fetch(`${process.env.API_HOST}/tasks/${id}/newCycle`, {
       method: 'POST',
       cache: 'no-store',
+      headers: {
+        ...getAuthHeader(),
+      },
     });
 
     if (res.ok) {
       const result: Task = (await res.json()) as Task;
       return NextResponse.json(result);
     } else {
-      return NextResponse.json({});
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
     }
   } catch (err) {
     console.error(err);
-    return NextResponse.json({});
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/task/[id]/reassign/route.ts
+++ b/src/app/api/task/[id]/reassign/route.ts
@@ -1,18 +1,11 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+
+import { getAuthHeaders } from '@/src/util/auth-headers';
 
 export type Task = {
   [key: string]: string | number;
-};
-
-/**
- * 認証ヘッダーを取得
- */
-const getAuthHeader = (): Record<string, string> => {
-  const token = cookies().get('token')?.value;
-  return token ? { Authorization: `Bearer ${token}` } : {};
 };
 
 export const PUT = async (
@@ -25,7 +18,7 @@ export const PUT = async (
       method: 'POST',
       cache: 'no-store',
       headers: {
-        ...getAuthHeader(),
+        ...getAuthHeaders(),
       },
     });
 

--- a/src/app/api/tasks/all/route.ts
+++ b/src/app/api/tasks/all/route.ts
@@ -2,6 +2,7 @@
 
 import { NextResponse } from 'next/server';
 
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { Task } from '@/src/types';
 import { getAuthHeaders } from '@/src/util/auth-headers';
 
@@ -19,10 +20,11 @@ export const GET = async () => {
       return NextResponse.json(result);
     } else {
       const errorText = await res.text().catch(() => '');
-      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
     }
   } catch (err) {
-    console.error(err);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[GET] /api/tasks/all:', errorMessage);
     return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/tasks/all/route.ts
+++ b/src/app/api/tasks/all/route.ts
@@ -1,16 +1,36 @@
 'use server';
 
+import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
-import { getTasks } from '@/src/api/get-tasks';
 import { Task } from '@/src/types';
+
+/**
+ * 認証ヘッダーを取得
+ */
+const getAuthHeader = (): Record<string, string> => {
+  const token = cookies().get('token')?.value;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};
 
 export const GET = async () => {
   try {
-    const res: Task[] = await getTasks();
-    return NextResponse.json(res);
+    const res = await fetch(`${process.env.API_HOST}/tasks?type=all`, {
+      cache: 'no-store',
+      headers: {
+        ...getAuthHeader(),
+      },
+    });
+
+    if (res.ok) {
+      const result: Task[] = (await res.json()) as Task[];
+      return NextResponse.json(result);
+    } else {
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [errorText || 'エラーが発生しました'] }, { status: res.status });
+    }
   } catch (err) {
     console.error(err);
-    return NextResponse.json(Array<Task>);
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/app/api/tasks/all/route.ts
+++ b/src/app/api/tasks/all/route.ts
@@ -1,24 +1,16 @@
 'use server';
 
-import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 
 import { Task } from '@/src/types';
-
-/**
- * 認証ヘッダーを取得
- */
-const getAuthHeader = (): Record<string, string> => {
-  const token = cookies().get('token')?.value;
-  return token ? { Authorization: `Bearer ${token}` } : {};
-};
+import { getAuthHeaders } from '@/src/util/auth-headers';
 
 export const GET = async () => {
   try {
     const res = await fetch(`${process.env.API_HOST}/tasks?type=all`, {
       cache: 'no-store',
       headers: {
-        ...getAuthHeader(),
+        ...getAuthHeaders(),
       },
     });
 

--- a/src/app/api/tasks/ng/route.ts
+++ b/src/app/api/tasks/ng/route.ts
@@ -2,19 +2,30 @@
 
 import { NextResponse } from 'next/server';
 
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { Task } from '@/src/types';
+import { getAuthHeaders } from '@/src/util/auth-headers';
 
 export const GET = async () => {
   try {
     const res = await fetch(`${process.env.API_HOST}/tasks?type=ng`, {
       method: 'GET',
       cache: 'no-store',
+      headers: {
+        ...getAuthHeaders(),
+      },
     });
 
-    const result: Task[] = (await res.json()) as Task[];
-    return NextResponse.json(result);
+    if (res.ok) {
+      const result: Task[] = (await res.json()) as Task[];
+      return NextResponse.json(result);
+    } else {
+      const errorText = await res.text().catch(() => '');
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
+    }
   } catch (err) {
-    console.error(err);
-    return NextResponse.json(Array<Task>);
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.error('[GET] /api/tasks/ng:', errorMessage);
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
   }
 };

--- a/src/components/AreaListCheck.tsx
+++ b/src/components/AreaListCheck.tsx
@@ -4,7 +4,7 @@ import { Checkbox, FormControlLabel, FormGroup, List } from '@mui/material';
 import { useCallback, useEffect, useState } from 'react';
 
 import { getAreas } from '../api/get-areas';
-import { Area } from '../types';
+import { Area, isErrorResponse } from '../types';
 
 const AreaListCheck = () => {
   const [checked, setChecked] = useState([0]);
@@ -26,6 +26,10 @@ const AreaListCheck = () => {
   const getArea = useCallback(async () => {
     try {
       const res = await getAreas();
+      if (isErrorResponse(res)) {
+        console.error('Failed to fetch areas:', res.errors);
+        return;
+      }
       setArea(res);
     } catch (err) {
       console.error(err);

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -201,7 +201,7 @@ const CommentList = (props: Props) => {
     (newRow: GridRowModel, updatedRow: GridRowModel) => {
       if (flagNewComment) {
         // 新規コメント作成
-        createComment(newRow.comment as string, props.account.id, props.cycleId)
+        createComment(newRow.comment as string, props.cycleId)
           .then((result) => {
             if (result.success && result.data) {
               const newId = result.data.id;
@@ -237,7 +237,7 @@ const CommentList = (props: Props) => {
           });
       }
     },
-    [flagNewComment, createComment, updateComment, props.account.id, props.cycleId, showSuccess, showError]
+    [flagNewComment, createComment, updateComment, props.cycleId, showSuccess, showError]
   );
 
   /**

--- a/src/domain/types/error.ts
+++ b/src/domain/types/error.ts
@@ -88,6 +88,12 @@ export const toDisplayError = (error: DomainError): string => {
 };
 
 /**
+ * 不正リクエストエラー（400）かどうかを判定
+ */
+export const isBadRequest = (error: DomainError): boolean =>
+  error.type === 'api' && error.status === 400;
+
+/**
  * 認証エラー（401）かどうかを判定
  */
 export const isUnauthorized = (error: DomainError): boolean =>
@@ -98,6 +104,12 @@ export const isUnauthorized = (error: DomainError): boolean =>
  */
 export const isForbidden = (error: DomainError): boolean =>
   error.type === 'api' && error.status === 403;
+
+/**
+ * 未検出エラー（404）かどうかを判定
+ */
+export const isNotFound = (error: DomainError): boolean =>
+  error.type === 'api' && error.status === 404;
 
 /**
  * 競合エラー（409）かどうかを判定

--- a/src/domain/types/error.ts
+++ b/src/domain/types/error.ts
@@ -86,3 +86,27 @@ export const toDisplayError = (error: DomainError): string => {
       return `ネットワークエラー: ${error.message}`;
   }
 };
+
+/**
+ * 認証エラー（401）かどうかを判定
+ */
+export const isUnauthorized = (error: DomainError): boolean =>
+  error.type === 'api' && error.status === 401;
+
+/**
+ * 権限エラー（403）かどうかを判定
+ */
+export const isForbidden = (error: DomainError): boolean =>
+  error.type === 'api' && error.status === 403;
+
+/**
+ * 競合エラー（409）かどうかを判定
+ */
+export const isConflict = (error: DomainError): boolean =>
+  error.type === 'api' && error.status === 409;
+
+/**
+ * サービス利用不可エラー（503）かどうかを判定
+ */
+export const isServiceUnavailable = (error: DomainError): boolean =>
+  error.type === 'api' && error.status === 503;

--- a/src/infra/http/serverClient.ts
+++ b/src/infra/http/serverClient.ts
@@ -31,7 +31,7 @@ type ServerRequestOptions = {
  * @param text - エラーレスポンスのボディテキスト
  * @returns 抽出されたエラーメッセージ、空の場合は'Unknown error'
  */
-const parseErrorMessage = (text: string): string => {
+export const parseErrorMessage = (text: string): string => {
   if (!text) return 'Unknown error';
   try {
     const json = JSON.parse(text) as Record<string, unknown>;

--- a/src/infra/http/serverClient.ts
+++ b/src/infra/http/serverClient.ts
@@ -20,6 +20,37 @@ type ServerRequestOptions = {
 };
 
 /**
+ * エラーレスポンスからメッセージを抽出
+ *
+ * 対応形式:
+ * - { errors: string[] } - 配列要素をカンマ区切りで結合
+ * - { message: string } - messageプロパティを返却
+ * - { error: string } - errorプロパティを返却
+ * - 上記以外のJSON/非JSON - 元のテキストをそのまま返却
+ *
+ * @param text - エラーレスポンスのボディテキスト
+ * @returns 抽出されたエラーメッセージ、空の場合は'Unknown error'
+ */
+const parseErrorMessage = (text: string): string => {
+  if (!text) return 'Unknown error';
+  try {
+    const json = JSON.parse(text) as Record<string, unknown>;
+    if (Array.isArray(json.errors) && json.errors.length > 0) {
+      return (json.errors as string[]).join(', ');
+    }
+    if (typeof json.message === 'string') {
+      return json.message;
+    }
+    if (typeof json.error === 'string') {
+      return json.error;
+    }
+  } catch {
+    // JSONパースに失敗した場合はそのままテキストを返す
+  }
+  return text;
+};
+
+/**
  * API_HOSTを取得（環境変数）
  */
 const getApiHost = (): string => {
@@ -72,8 +103,8 @@ export const serverHttpClient = {
       });
 
       if (!res.ok) {
-        const message = await res.text().catch(() => 'Unknown error');
-        return err(createApiError(res.status, message));
+        const text = await res.text().catch(() => '');
+        return err(createApiError(res.status, parseErrorMessage(text)));
       }
 
       const data = (await res.json()) as T;
@@ -106,8 +137,8 @@ export const serverHttpClient = {
       });
 
       if (!res.ok) {
-        const message = await res.text().catch(() => 'Unknown error');
-        return err(createApiError(res.status, message));
+        const text = await res.text().catch(() => '');
+        return err(createApiError(res.status, parseErrorMessage(text)));
       }
 
       const data = (await res.json()) as T;

--- a/src/infra/http/serverClient.ts
+++ b/src/infra/http/serverClient.ts
@@ -35,7 +35,11 @@ export const parseErrorMessage = (text: string): string => {
   if (!text) return 'Unknown error';
   try {
     const json = JSON.parse(text) as Record<string, unknown>;
-    if (Array.isArray(json.errors) && json.errors.length > 0) {
+    if (Array.isArray(json.errors)) {
+      // 空配列の場合はUnknown errorを返す
+      if (json.errors.length === 0) {
+        return 'Unknown error';
+      }
       return (json.errors as string[]).join(', ');
     }
     if (typeof json.message === 'string') {

--- a/src/mutations/useCommentMutation.ts
+++ b/src/mutations/useCommentMutation.ts
@@ -16,16 +16,15 @@ type MutationResult<T> = {
 export const useCommentMutation = () => {
   /**
    * 新しいコメントを作成
+   * account_idはサーバー側で認証ユーザーから自動設定される
    */
   const createComment = useCallback(
     async (
       content: string,
-      accountId: number,
       cycleId: number
     ): Promise<MutationResult<Comment>> => {
       const result = await httpClient.post<Comment>('/api/comment', {
         content,
-        accountId,
         taskId: cycleId,
       });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,12 +60,14 @@ export interface ErrorResponse {
 
 /**
  * ErrorResponseかどうかを判定する型ガード
+ * errors配列の要素が全てstring型であることも検証する
  */
 export const isErrorResponse = (value: unknown): value is ErrorResponse =>
   typeof value === 'object' &&
   value !== null &&
   'errors' in value &&
-  Array.isArray((value as ErrorResponse).errors);
+  Array.isArray((value as ErrorResponse).errors) &&
+  (value as ErrorResponse).errors.every((e) => typeof e === 'string');
 
 export type ApiResult<T> = T | ErrorResponse;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,8 +55,7 @@ export type GroupKey = 'time' | 'area';
 
 // API共通型
 export interface ErrorResponse {
-  message: string;
-  code?: string;
+  errors: string[];
 }
 
 export type ApiResult<T> = T | ErrorResponse;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,6 +58,15 @@ export interface ErrorResponse {
   errors: string[];
 }
 
+/**
+ * ErrorResponseかどうかを判定する型ガード
+ */
+export const isErrorResponse = (value: unknown): value is ErrorResponse =>
+  typeof value === 'object' &&
+  value !== null &&
+  'errors' in value &&
+  Array.isArray((value as ErrorResponse).errors);
+
 export type ApiResult<T> = T | ErrorResponse;
 
 // API固有のレスポンス型

--- a/src/util/auth-headers.ts
+++ b/src/util/auth-headers.ts
@@ -8,5 +8,9 @@ import { cookies } from 'next/headers';
  */
 export const getAuthHeaders = (): Record<string, string> => {
   const token = cookies().get('token')?.value;
-  return token ? { Authorization: `Bearer ${token}` } : {};
+  if (!token) {
+    console.warn('[getAuthHeaders] 認証トークンが見つかりません');
+    return {};
+  }
+  return { Authorization: `Bearer ${token}` };
 };

--- a/src/util/auth-headers.ts
+++ b/src/util/auth-headers.ts
@@ -1,0 +1,12 @@
+import { cookies } from 'next/headers';
+
+/**
+ * 認証ヘッダーを取得するユーティリティ
+ * Server Actions/Route Handlersで使用
+ *
+ * @returns 認証ヘッダーオブジェクト（トークンがなければ空オブジェクト）
+ */
+export const getAuthHeaders = (): Record<string, string> => {
+  const token = cookies().get('token')?.value;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};


### PR DESCRIPTION
## Summary

- バックエンドの4層アーキテクチャ移行（PR #61〜#80）による破壊的変更に対応
- 全APIエンドポイントで認証ヘッダー（Bearer token）を送信するように変更
- コメント作成時のaccount_id引数を削除（サーバー側で自動設定）

## 変更内容

### Route Handlers（9ファイル）
認証ヘッダー追加:
- src/app/api/comment/route.ts - POST/PUT/DELETE
- src/app/api/comments/route.ts - GET
- src/app/api/tasks/all/route.ts - GET
- src/app/api/task/[id]/complete/route.ts - PUT
- src/app/api/task/[id]/ng/route.ts - PUT
- src/app/api/task/[id]/reassign/route.ts - PUT
- src/app/api/account/[id]/route.ts - DELETE
- src/app/api/account/[id]/tasks/route.ts - GET
- src/app/api/areas/route.ts - GET

### Server Actions（8ファイル）
認証ヘッダー追加:
- src/api/get-tasks.ts
- src/api/get-areas.ts
- src/api/get-account-tasks.ts
- src/api/get-unfulfilled-count.ts
- src/api/get-week-complete.ts
- src/api/get-account-status.ts
- src/api/post-task-create.ts

### Infra/Domain
- src/util/auth-headers.ts - 新規作成
- src/infra/http/serverClient.ts - エラーメッセージパース機能追加
- src/domain/types/error.ts - 401/403/409/503判定ヘルパー追加

### Mutations/Types
- src/mutations/useCommentMutation.ts - accountId引数削除
- src/types/index.ts - ErrorResponse型更新

## Test plan

- [x] ESLint: 警告・エラーなし
- [x] Jest: 181件全Pass
- [x] 手動テスト: ログイン→各機能動作確認
- [x] 手動テスト: 認証なしアクセス→401エラー確認