### PR TITLE
fix: ERR-003/ERR-004 サイレント認証失敗を修正

### DIFF
--- a/src/__tests__/admin/AccountCreate.test.tsx
+++ b/src/__tests__/admin/AccountCreate.test.tsx
@@ -143,4 +143,56 @@ describe('AccountCreate', () => {
       ).toBeInTheDocument();
     });
   });
+
+  // ERR-004: サーバーがデフォルトエラーメッセージを返した場合
+  // TYPE-001: 判別共用体により、success: falseの場合はerrorが必須
+  test('shows default error message from server', async () => {
+    const mockSignUpAction = singUpAction as jest.Mock;
+    mockSignUpAction.mockResolvedValueOnce({
+      success: false,
+      error: 'アカウント作成に失敗しました', // 判別共用体によりerrorは必須
+    });
+
+    render(<AccountCreate />);
+    const nameInput = screen.getByPlaceholderText('例: 山田太郎');
+    const passwordInput = document.querySelector('input[name="password"]') as HTMLInputElement;
+    const capacityInput = screen.getByRole('spinbutton');
+    const submitButton = screen.getByRole('button', { name: /アカウントを作成/i });
+
+    fireEvent.change(nameInput, { target: { value: 'TestUser' } });
+    fireEvent.change(passwordInput, { target: { value: 'Password123' } });
+    fireEvent.change(capacityInput, { target: { value: '5' } });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('アカウント作成に失敗しました'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ERR-004: ネットワークエラー等の例外発生時のエラー表示
+  test('shows error when signup action throws exception', async () => {
+    const mockSignUpAction = singUpAction as jest.Mock;
+    mockSignUpAction.mockRejectedValueOnce(new Error('Network error'));
+
+    render(<AccountCreate />);
+    const nameInput = screen.getByPlaceholderText('例: 山田太郎');
+    const passwordInput = document.querySelector('input[name="password"]') as HTMLInputElement;
+    const capacityInput = screen.getByRole('spinbutton');
+    const submitButton = screen.getByRole('button', { name: /アカウントを作成/i });
+
+    fireEvent.change(nameInput, { target: { value: 'TestUser' } });
+    fireEvent.change(passwordInput, { target: { value: 'Password123' } });
+    fireEvent.change(capacityInput, { target: { value: '5' } });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('アカウント作成に失敗しました'),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/__tests__/admin/AccountCreate.test.tsx
+++ b/src/__tests__/admin/AccountCreate.test.tsx
@@ -4,9 +4,9 @@ import '@testing-library/jest-dom';
 import AccountCreate from '@/src/app/(admin)/account/create/page';
 import { singUpAction } from '@/src/util/actions/signUp';
 
-// モックの作成
+// ERR-004: SignUpResult型に合わせたモック
 jest.mock('@/src/util/actions/signUp', () => ({
-  singUpAction: jest.fn().mockResolvedValue(undefined),
+  singUpAction: jest.fn().mockResolvedValue({ success: true }),
 }));
 
 // AreaListCheckモック - チェックボックスを含む
@@ -114,6 +114,33 @@ describe('AccountCreate', () => {
 
     await waitFor(() => {
       expect(singUpAction).toHaveBeenCalledWith(expect.any(FormData));
+    });
+  });
+
+  // ERR-004: サーバーからのエラーが表示されることを確認
+  test('shows server error when signup fails', async () => {
+    const mockSignUpAction = singUpAction as jest.Mock;
+    mockSignUpAction.mockResolvedValueOnce({
+      success: false,
+      error: 'アカウント名が既に使用されています',
+    });
+
+    render(<AccountCreate />);
+    const nameInput = screen.getByPlaceholderText('例: 山田太郎');
+    const passwordInput = document.querySelector('input[name="password"]') as HTMLInputElement;
+    const capacityInput = screen.getByRole('spinbutton');
+    const submitButton = screen.getByRole('button', { name: /アカウントを作成/i });
+
+    fireEvent.change(nameInput, { target: { value: 'TestUser' } });
+    fireEvent.change(passwordInput, { target: { value: 'Password123' } });
+    fireEvent.change(capacityInput, { target: { value: '5' } });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('アカウント名が既に使用されています'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/__tests__/app/LoginPage.test.tsx
+++ b/src/__tests__/app/LoginPage.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SignInSide from '@/src/app/page';
+
+// next/navigationのモック
+const mockSearchParams = new Map<string, string>();
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => ({
+    get: (key: string) => mockSearchParams.get(key) ?? null,
+  }),
+}));
+
+// loginActionのモック
+jest.mock('@/src/util/actions/login', () => ({
+  loginAction: jest.fn(),
+}));
+
+describe('LoginPage (SignInSide)', () => {
+  beforeEach(() => {
+    mockSearchParams.clear();
+  });
+
+  test('renders login form', () => {
+    render(<SignInSide />);
+    // MUIのTextFieldはinputにname属性を持つ
+    expect(document.querySelector('input[name="name"]')).toBeInTheDocument();
+    expect(document.querySelector('input[name="password"]')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /ログイン/i })).toBeInTheDocument();
+  });
+
+  test('renders PHOTO IN branding', () => {
+    render(<SignInSide />);
+    expect(screen.getAllByText('PHOTO IN').length).toBeGreaterThan(0);
+  });
+
+  // ERR-003: エラークエリパラメータからエラーメッセージを表示
+  test('displays error message from query parameter', () => {
+    mockSearchParams.set('error', 'ログインに失敗しました');
+    render(<SignInSide />);
+    expect(screen.getByText('ログインに失敗しました')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  // ERR-003: URL エンコードされたエラーメッセージも正しく表示
+  test('displays URL-decoded error message', () => {
+    mockSearchParams.set('error', 'アカウント名またはパスワードが正しくありません');
+    render(<SignInSide />);
+    expect(
+      screen.getByText('アカウント名またはパスワードが正しくありません'),
+    ).toBeInTheDocument();
+  });
+
+  // ERR-003: エラーがない場合はアラートを表示しない
+  test('does not display error alert when no error query param', () => {
+    render(<SignInSide />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+});

--- a/src/api/post-login.ts
+++ b/src/api/post-login.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { serverHttpClient } from '@/src/infra/http';
+import { ErrorResponse } from '@/src/types';
 import { logError } from '@/src/util/safe-logger';
 
 export interface Account {
@@ -14,10 +15,11 @@ type LoginResponse = {
   account: Account;
 };
 
+// ERR-003: エラー時にErrorResponseを返すように変更
 export async function postLogin(
   name: string,
   password: string,
-): Promise<Account | Record<string, never>> {
+): Promise<Account | ErrorResponse> {
   const result = await serverHttpClient.post<LoginResponse>(
     '/account/login',
     { account: { name, password } },
@@ -28,5 +30,5 @@ export async function postLogin(
     return result.value.account;
   }
   logError('[postLogin]', result.error.message);
-  return {};
+  return { errors: [result.error.message] };
 }

--- a/src/api/post-signup.ts
+++ b/src/api/post-signup.ts
@@ -1,16 +1,17 @@
 'use server';
 
 import { serverHttpClient } from '@/src/infra/http';
-import { AccountData } from '@/src/types';
+import { AccountData, ErrorResponse } from '@/src/types';
 import { logError } from '@/src/util/safe-logger';
 
+// ERR-004: エラー時にErrorResponseを返すように変更
 export const postSignup = async (
   name: string,
   password: string,
   area: string[],
   role: string,
   capacity: number,
-): Promise<AccountData | Record<string, never>> => {
+): Promise<AccountData | ErrorResponse> => {
   const result = await serverHttpClient.post<AccountData>(
     '/accounts',
     {
@@ -29,5 +30,5 @@ export const postSignup = async (
     return result.value;
   }
   logError('[postSignup]', result.error.message);
-  return {};
+  return { errors: [result.error.message] };
 };

--- a/src/app/(admin)/account/create/page.tsx
+++ b/src/app/(admin)/account/create/page.tsx
@@ -59,7 +59,12 @@ const AccountCreate = () => {
 
     setIsSubmitting(true);
     try {
-      await singUpAction(data);
+      // ERR-004: サーバーアクションからのエラーを処理
+      const result = await singUpAction(data);
+      if (!result.success) {
+        setError(result.error || 'アカウント作成に失敗しました');
+      }
+      // 成功時はサーバーアクション内でリダイレクトされる
     } catch (err) {
       setError('アカウント作成に失敗しました');
       console.error('Account creation failed:', err);

--- a/src/app/(admin)/account/create/page.tsx
+++ b/src/app/(admin)/account/create/page.tsx
@@ -63,7 +63,8 @@ const AccountCreate = () => {
       // ERR-004: サーバーアクションからのエラーを処理
       const result = await singUpAction(data);
       if (!result.success) {
-        setError(result.error || 'アカウント作成に失敗しました');
+        // TYPE-001: 判別共用体によりresult.errorは必ずstring
+        setError(result.error);
       }
       // 成功時はサーバーアクション内でリダイレクトされる
     } catch (err) {

--- a/src/app/(admin)/account/create/page.tsx
+++ b/src/app/(admin)/account/create/page.tsx
@@ -16,6 +16,7 @@ import { useState } from 'react';
 import AreaListCheck from '@/src/components/AreaListCheck';
 import RoleRadioButton from '@/src/components/RoleRadioButton';
 import { singUpAction } from '@/src/util/actions/signUp';
+import { logError } from '@/src/util/safe-logger';
 
 const AccountCreate = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -67,7 +68,7 @@ const AccountCreate = () => {
       // 成功時はサーバーアクション内でリダイレクトされる
     } catch (err) {
       setError('アカウント作成に失敗しました');
-      console.error('Account creation failed:', err);
+      logError('[AccountCreate] handleSubmit', err);
     } finally {
       setIsSubmitting(false);
     }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,16 +3,21 @@
 import CameraAltIcon from '@mui/icons-material/CameraAlt';
 import LoginIcon from '@mui/icons-material/Login';
 import {
+  Alert,
   Box,
   Button,
   Paper,
   TextField,
   Typography,
 } from '@mui/material';
+import { useSearchParams } from 'next/navigation';
 
 import { loginAction } from '../util/actions/login';
 
+// ERR-003: エラー時にクエリパラメータからエラーメッセージを表示
 const SignInSide = () => {
+  const searchParams = useSearchParams();
+  const errorMessage = searchParams.get('error');
   return (
     <Box
       sx={{
@@ -192,6 +197,13 @@ const SignInSide = () => {
                 アカウント情報を入力してください
               </Typography>
             </Box>
+
+            {/* ERR-003: エラーメッセージ表示 */}
+            {errorMessage && (
+              <Alert severity="error" sx={{ mb: 3, borderRadius: 2 }}>
+                {errorMessage}
+              </Alert>
+            )}
 
             {/* eslint-disable @typescript-eslint/no-misused-promises */}
             <form action={loginAction}>

--- a/src/util/actions/login.ts
+++ b/src/util/actions/login.ts
@@ -2,7 +2,6 @@
 import { redirect, RedirectType } from 'next/navigation';
 
 import { postLogin } from '@/src/api/post-login';
-import { isErrorResponse } from '@/src/types';
 
 import { setCookies } from '../cookies';
 
@@ -13,7 +12,9 @@ export async function loginAction(formData: FormData) {
 
   const result = await postLogin(name, password);
 
+  // postLoginの戻り値はAccount | ErrorResponseの判別共用体
   if ('token' in result) {
+    // Account: ログイン成功
     setCookies('token', result.token);
     // SEC-006: 認可チェック用にロール情報をCookieに保存
     setCookies('role', result.role);
@@ -22,11 +23,9 @@ export async function loginAction(formData: FormData) {
     } else {
       redirect(`/member/${result.id}`, RedirectType.push);
     }
-  } else if (isErrorResponse(result)) {
-    // エラーメッセージをクエリパラメータで渡す
+  } else {
+    // ErrorResponse: ログイン失敗
     const errorMessage = encodeURIComponent(result.errors[0] || 'ログインに失敗しました');
     redirect(`/?error=${errorMessage}`, RedirectType.push);
-  } else {
-    redirect('/?error=' + encodeURIComponent('ログインに失敗しました'), RedirectType.push);
   }
 }

--- a/src/util/actions/login.ts
+++ b/src/util/actions/login.ts
@@ -2,9 +2,11 @@
 import { redirect, RedirectType } from 'next/navigation';
 
 import { postLogin } from '@/src/api/post-login';
+import { isErrorResponse } from '@/src/types';
 
 import { setCookies } from '../cookies';
 
+// ERR-003: エラー時にクエリパラメータでエラーメッセージを渡す
 export async function loginAction(formData: FormData) {
   const name = String(formData.get('name'));
   const password = String(formData.get('password'));
@@ -20,7 +22,11 @@ export async function loginAction(formData: FormData) {
     } else {
       redirect(`/member/${result.id}`, RedirectType.push);
     }
+  } else if (isErrorResponse(result)) {
+    // エラーメッセージをクエリパラメータで渡す
+    const errorMessage = encodeURIComponent(result.errors[0] || 'ログインに失敗しました');
+    redirect(`/?error=${errorMessage}`, RedirectType.push);
   } else {
-    redirect('/', RedirectType.push);
+    redirect('/?error=' + encodeURIComponent('ログインに失敗しました'), RedirectType.push);
   }
 }

--- a/src/util/actions/signUp.ts
+++ b/src/util/actions/signUp.ts
@@ -12,10 +12,21 @@ export type SignUpResult = {
 };
 
 export const singUpAction = async (formData: FormData): Promise<SignUpResult> => {
-  const area = JSON.parse(formData.get('area') as string) as string[];
+  // エリア情報のパース（JSON.parseはSyntaxErrorをスローする可能性がある）
+  let area: string[];
+  try {
+    const areaString = formData.get('area');
+    if (!areaString || typeof areaString !== 'string') {
+      return { success: false, error: 'エリア情報が不正です' };
+    }
+    area = JSON.parse(areaString) as string[];
+  } catch {
+    return { success: false, error: 'エリア情報の形式が不正です' };
+  }
+
   const capacity = formData.get('capacity');
 
-  if (area === null || !(area instanceof Array) || capacity === null) {
+  if (!(area instanceof Array) || capacity === null) {
     return { success: false, error: '入力データが不正です' };
   }
 

--- a/src/util/actions/signUp.ts
+++ b/src/util/actions/signUp.ts
@@ -6,10 +6,10 @@ import { postSignup } from '@/src/api/post-signup';
 import { isErrorResponse } from '@/src/types';
 
 // ERR-004: エラー時にエラーメッセージを返すように変更
-export type SignUpResult = {
-  success: boolean;
-  error?: string;
-};
+// TYPE-001: 判別共用体で不正な状態を型レベルで防止
+export type SignUpResult =
+  | { success: true }
+  | { success: false; error: string };
 
 export const singUpAction = async (formData: FormData): Promise<SignUpResult> => {
   // エリア情報のパース（JSON.parseはSyntaxErrorをスローする可能性がある）

--- a/src/util/actions/signUp.ts
+++ b/src/util/actions/signUp.ts
@@ -3,21 +3,34 @@
 import { redirect, RedirectType } from 'next/navigation';
 
 import { postSignup } from '@/src/api/post-signup';
+import { isErrorResponse } from '@/src/types';
 
-export const singUpAction = async (formData: FormData) => {
+// ERR-004: エラー時にエラーメッセージを返すように変更
+export type SignUpResult = {
+  success: boolean;
+  error?: string;
+};
+
+export const singUpAction = async (formData: FormData): Promise<SignUpResult> => {
   const area = JSON.parse(formData.get('area') as string) as string[];
   const capacity = formData.get('capacity');
-  if (area !== null && area instanceof Array && capacity !== null) {
-    const result = await postSignup(
-      String(formData.get('name')),
-      String(formData.get('password')),
-      area,
-      String(formData.get('role')),
-      parseInt(String(capacity)),
-    );
 
-    if ('account' in result) {
-      redirect('/members', RedirectType.push);
-    }
+  if (area === null || !(area instanceof Array) || capacity === null) {
+    return { success: false, error: '入力データが不正です' };
   }
+
+  const result = await postSignup(
+    String(formData.get('name')),
+    String(formData.get('password')),
+    area,
+    String(formData.get('role')),
+    parseInt(String(capacity)),
+  );
+
+  if (isErrorResponse(result)) {
+    return { success: false, error: result.errors[0] || 'アカウント作成に失敗しました' };
+  }
+
+  // 成功時はリダイレクト
+  redirect('/members', RedirectType.push);
 };


### PR DESCRIPTION
## Summary

- ログイン/サインアップ失敗時にユーザーにエラーメッセージが表示されない問題（サイレント認証失敗）を修正
- PR#96レビューで発見されたCritical問題への対応

## 変更内容

### API層
- `postLogin`: エラー時に空オブジェクト`{}`ではなく`ErrorResponse`型を返すように変更
- `postSignup`: 同上

### Action層
- `loginAction`: `isErrorResponse()`でエラー判定、クエリパラメータ`?error=`でエラーメッセージを渡す
- `singUpAction`: `SignUpResult`型を返し、`success: false`時に`error`プロパティを設定

### ページ層
- ログインページ: `useSearchParams`でエラークエリパラメータを読み取り、Alertコンポーネントで表示
- アカウント作成ページ: `SignUpResult.success`をチェックし、失敗時にエラーをAlertで表示

### テスト
- `AccountCreate.test.tsx`: サーバーエラー時のエラー表示テストを追加

## 修正前後の動作

| シナリオ | 修正前 | 修正後 |
|----------|--------|--------|
| ログイン失敗 | トップページにリダイレクト（エラー表示なし） | `/?error=メッセージ`にリダイレクト→Alertで表示 |
| サインアップ失敗 | 何も起きない | ページ内Alertでエラーメッセージ表示 |

## Test plan

- [x] `npm test` 全330件Pass
- [x] `npm run lint` Pass
- [ ] 手動確認: 不正なログイン情報でログイン→エラーメッセージが表示される
- [ ] 手動確認: 重複アカウント名でサインアップ→エラーメッセージが表示される