### PR TITLE
test: TEST-004 Cookie操作テスト追加

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -11,9 +11,9 @@
 |--------|------|------|------|
 | Critical | 2 | 2 | 0 |
 | High | 11 | 8 | 3 |
-| Medium | 15 | 7 | 8 |
+| Medium | 15 | 9 | 6 |
 | Low | 6 | 0 | 6 |
-| **合計** | **34** | **17** | **17** |
+| **合計** | **34** | **19** | **15** |
 
 ---
 
@@ -135,10 +135,12 @@
 
 ### パフォーマンス
 
-- [ ] **PERF-001**: `useTaskDetail`をSWR化
+- [x] **PERF-001**: `useTaskDetail`をSWR化 ✅完了
   - ファイル: `src/queries/useTaskDetail.ts`
   - 問題: 手動Mapキャッシュがメモリリーク、有効期限なし
-  - 工数: 4h
+  - 対応: SWRの条件付きフェッチに移行、配列キー形式で特殊文字対応、エラー状態のUI表示追加
+  - テスト: `src/__tests__/queries/useTaskDetail.test.tsx`, `src/__tests__/components/TaskAccordion.test.tsx`
+  - 完了日: 2025-12-27
 
 - [ ] **PERF-002**: ダッシュボードN+1クエリ解消
   - ファイル: `src/components/Orders.tsx`, `src/components/Uncompletes.tsx`
@@ -250,10 +252,11 @@
   - 対象: `src/util/actions/signUp.ts`
   - 工数: 2h
 
-- [ ] **TEST-004**: Cookie操作テスト追加
+- [x] **TEST-004**: Cookie操作テスト追加 ✅完了
   - ファイル: `src/__tests__/util/cookies.test.ts`（新規）
   - 対象: `src/util/cookies.ts`
-  - 工数: 2h
+  - 対応: getCookies, setCookies, deleteCookieの全機能テスト追加（13テスト）、SEC-003のsameSite/secure属性検証含む
+  - 完了日: 2025-12-27
 
 - [ ] **TEST-005**: グルーピング関数テスト追加
   - ファイル: `src/__tests__/util/grouping.test.ts`（新規）
@@ -338,6 +341,8 @@
 | 2025-12-27 | CODE-006 | console.log/errorの統一 | Claude |
 | 2025-12-27 | CODE-007 | Task型定義の厳格化 | Claude |
 | 2025-12-27 | CODE-008 | CommentApiResponse型の厳格化 | Claude |
+| 2025-12-27 | PERF-001 | useTaskDetailをSWR化 | Claude |
+| 2025-12-27 | TEST-004 | Cookie操作テスト追加 | Claude |
 
 ---
 

--- a/src/__tests__/util/cookies.test.ts
+++ b/src/__tests__/util/cookies.test.ts
@@ -1,0 +1,217 @@
+import { cookies } from 'next/headers';
+
+import { getCookies, setCookies, deleteCookie } from '@/src/util/cookies';
+
+// next/headersのcookies関数をモック
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}));
+
+const mockCookies = cookies as jest.MockedFunction<typeof cookies>;
+
+describe('cookies utility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Date.nowをモック
+    jest.spyOn(Date, 'now').mockReturnValue(1704067200000); // 2024-01-01 00:00:00 UTC
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getCookies', () => {
+    test('指定した名前のCookieの値を返す', () => {
+      mockCookies.mockReturnValue({
+        get: jest.fn().mockReturnValue({ value: 'test-value' }),
+      } as unknown as ReturnType<typeof cookies>);
+
+      const result = getCookies('token');
+
+      expect(result).toBe('test-value');
+    });
+
+    test('Cookieが存在しない場合はundefinedを返す', () => {
+      mockCookies.mockReturnValue({
+        get: jest.fn().mockReturnValue(undefined),
+      } as unknown as ReturnType<typeof cookies>);
+
+      const result = getCookies('nonexistent');
+
+      expect(result).toBeUndefined();
+    });
+
+    test('正しい名前でCookieを取得する', () => {
+      const mockGet = jest.fn().mockReturnValue({ value: 'value' });
+      mockCookies.mockReturnValue({
+        get: mockGet,
+      } as unknown as ReturnType<typeof cookies>);
+
+      getCookies('my-cookie');
+
+      expect(mockGet).toHaveBeenCalledWith('my-cookie');
+    });
+  });
+
+  describe('setCookies', () => {
+    test('正しいオプションでCookieを設定する', () => {
+      const mockSet = jest.fn();
+      mockCookies.mockReturnValue({
+        set: mockSet,
+      } as unknown as ReturnType<typeof cookies>);
+
+      setCookies('token', 'jwt-token-123');
+
+      expect(mockSet).toHaveBeenCalledWith({
+        name: 'token',
+        value: 'jwt-token-123',
+        expires: 1704067200000 + 24 * 60 * 60 * 1000, // 24時間後
+        httpOnly: true,
+        path: '/',
+        sameSite: 'strict',
+        secure: false, // test環境ではNODE_ENV !== 'production'
+      });
+    });
+
+    test('SEC-003: sameSite属性が"strict"に設定されている', () => {
+      const mockSet = jest.fn();
+      mockCookies.mockReturnValue({
+        set: mockSet,
+      } as unknown as ReturnType<typeof cookies>);
+
+      setCookies('session', 'session-value');
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sameSite: 'strict',
+        }),
+      );
+    });
+
+    test('httpOnly属性がtrueに設定されている', () => {
+      const mockSet = jest.fn();
+      mockCookies.mockReturnValue({
+        set: mockSet,
+      } as unknown as ReturnType<typeof cookies>);
+
+      setCookies('auth', 'auth-value');
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          httpOnly: true,
+        }),
+      );
+    });
+
+    test('path属性が"/"に設定されている', () => {
+      const mockSet = jest.fn();
+      mockCookies.mockReturnValue({
+        set: mockSet,
+      } as unknown as ReturnType<typeof cookies>);
+
+      setCookies('data', 'data-value');
+
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/',
+        }),
+      );
+    });
+
+    test('有効期限が24時間後に設定される', () => {
+      const mockSet = jest.fn();
+      mockCookies.mockReturnValue({
+        set: mockSet,
+      } as unknown as ReturnType<typeof cookies>);
+
+      setCookies('temp', 'temp-value');
+
+      const expectedExpires = 1704067200000 + 24 * 60 * 60 * 1000;
+      expect(mockSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expires: expectedExpires,
+        }),
+      );
+    });
+
+    describe('secure属性', () => {
+      const originalEnv = process.env.NODE_ENV;
+
+      afterEach(() => {
+        process.env.NODE_ENV = originalEnv;
+      });
+
+      test('本番環境ではsecure属性がtrueになる', () => {
+        process.env.NODE_ENV = 'production';
+        const mockSet = jest.fn();
+        mockCookies.mockReturnValue({
+          set: mockSet,
+        } as unknown as ReturnType<typeof cookies>);
+
+        setCookies('secure-cookie', 'secure-value');
+
+        expect(mockSet).toHaveBeenCalledWith(
+          expect.objectContaining({
+            secure: true,
+          }),
+        );
+      });
+
+      test('開発環境ではsecure属性がfalseになる', () => {
+        process.env.NODE_ENV = 'development';
+        const mockSet = jest.fn();
+        mockCookies.mockReturnValue({
+          set: mockSet,
+        } as unknown as ReturnType<typeof cookies>);
+
+        setCookies('dev-cookie', 'dev-value');
+
+        expect(mockSet).toHaveBeenCalledWith(
+          expect.objectContaining({
+            secure: false,
+          }),
+        );
+      });
+
+      test('テスト環境ではsecure属性がfalseになる', () => {
+        process.env.NODE_ENV = 'test';
+        const mockSet = jest.fn();
+        mockCookies.mockReturnValue({
+          set: mockSet,
+        } as unknown as ReturnType<typeof cookies>);
+
+        setCookies('test-cookie', 'test-value');
+
+        expect(mockSet).toHaveBeenCalledWith(
+          expect.objectContaining({
+            secure: false,
+          }),
+        );
+      });
+    });
+  });
+
+  describe('deleteCookie', () => {
+    test('指定した名前のCookieを削除する', () => {
+      const mockDelete = jest.fn();
+      mockCookies.mockReturnValue({
+        delete: mockDelete,
+      } as unknown as ReturnType<typeof cookies>);
+
+      deleteCookie('token');
+
+      expect(mockDelete).toHaveBeenCalledWith('token');
+    });
+
+    test('正しい名前でCookieを削除する', () => {
+      const mockDelete = jest.fn();
+      mockCookies.mockReturnValue({
+        delete: mockDelete,
+      } as unknown as ReturnType<typeof cookies>);
+
+      deleteCookie('my-session');
+
+      expect(mockDelete).toHaveBeenCalledWith('my-session');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Cookie操作ユーティリティ（`src/util/cookies.ts`）のテストを追加
- SEC-003セキュリティ修正（sameSite/secure属性）の検証を含む
- PERF-001完了をTODO.mdに反映

## 変更内容
- `src/__tests__/util/cookies.test.ts`を新規作成（13テスト）
  - `getCookies`: Cookie取得テスト
  - `setCookies`: Cookie設定テスト（sameSite, secure, httpOnly, path, expires）
  - `deleteCookie`: Cookie削除テスト
  - 環境別secure属性テスト（production/development/test）

## Test plan
- [x] `npm test -- cookies.test.ts` パス確認（13テスト）
- [x] `npm test` 全テストパス確認（356テスト）