### PR TITLE
perf: PERF-005 MemberCardにmemo()追加

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -11,9 +11,9 @@
 |--------|------|------|------|
 | Critical | 2 | 2 | 0 |
 | High | 11 | 8 | 3 |
-| Medium | 15 | 10 | 5 |
+| Medium | 15 | 11 | 4 |
 | Low | 6 | 0 | 6 |
-| **合計** | **34** | **20** | **14** |
+| **合計** | **34** | **21** | **13** |
 
 ---
 
@@ -158,10 +158,11 @@
   - 対応: `styled-components`と`@mui/styled-engine-sc`を削除（12パッケージ削減）
   - 完了日: 2025-12-27
 
-- [ ] **PERF-005**: `MemberCard`にmemo()追加
+- [x] **PERF-005**: `MemberCard`にmemo()追加 ✅完了
   - ファイル: `src/components/MemberCard.tsx`
   - 問題: リスト再レンダー時に全カードが再レンダー
-  - 工数: 30m
+  - 対応: `memo()`でコンポーネントをラップし不要な再レンダー防止
+  - 完了日: 2025-12-27
 
 - [ ] **PERF-006**: Orders/UncompleteをSWR使用に変更
   - ファイル: `src/components/Orders.tsx`, `src/components/Uncompletes.tsx`
@@ -345,6 +346,7 @@
 | 2025-12-27 | PERF-001 | useTaskDetailをSWR化 | Claude |
 | 2025-12-27 | TEST-004 | Cookie操作テスト追加 | Claude |
 | 2025-12-27 | PERF-004 | styled-components依存関係削除 | Claude |
+| 2025-12-27 | PERF-005 | MemberCardにmemo()追加 | Claude |
 
 ---
 

--- a/src/app/(admin)/members/page.tsx
+++ b/src/app/(admin)/members/page.tsx
@@ -15,7 +15,7 @@ import {
   Typography,
 } from '@mui/material';
 import Link from 'next/link';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getAccountStatus } from '@/src/api/get-account-status';
 import MemberCard from '@/src/components/MemberCard';
@@ -40,9 +40,9 @@ const Members = () => {
     void fetchData();
   }, []);
 
-  const handleDelete = (id: number) => {
-    setMembersStatus(membersStatus.filter((member) => member.id !== id));
-  };
+  const handleDelete = useCallback((id: number) => {
+    setMembersStatus((prev) => prev.filter((member) => member.id !== id));
+  }, []);
 
   // 検索フィルタリング
   const filteredMembers = useMemo(() => {

--- a/src/components/MemberCard.tsx
+++ b/src/components/MemberCard.tsx
@@ -18,6 +18,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { memo } from 'react';
 
 import { useToast } from '@/src/context/ToastContext';
 import { parseIsoToYYYYMMDD } from '@/src/domain/functions/date';
@@ -266,4 +267,4 @@ const MemberCard = (props: Props) => {
   );
 };
 
-export default MemberCard;
+export default memo(MemberCard);


### PR DESCRIPTION
## Summary
- `MemberCard`コンポーネントを`memo()`でラップ
- リスト再レンダー時の不要な再レンダリングを防止

## 変更内容
- `import { memo } from 'react'`追加
- `export default memo(MemberCard)`に変更

## Test plan
- [x] `npm test` 全テストPass（356件）