### PR TITLE
perf: Route Handlersにキャッシュヘッダー追加（PERF-003）

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -11,9 +11,9 @@
 |--------|------|------|------|
 | Critical | 2 | 2 | 0 |
 | High | 11 | 8 | 3 |
-| Medium | 15 | 11 | 4 |
+| Medium | 15 | 12 | 3 |
 | Low | 6 | 0 | 6 |
-| **合計** | **34** | **21** | **13** |
+| **合計** | **34** | **22** | **12** |
 
 ---
 
@@ -147,10 +147,12 @@
   - 問題: 3つのAPIが個別に呼び出され、バッチ化されていない
   - 工数: 3h
 
-- [ ] **PERF-003**: Route Handlersにキャッシュヘッダー追加
-  - ファイル: `src/app/api/tasks/all/route.ts`
+- [x] **PERF-003**: Route Handlersにキャッシュヘッダー追加 ✅完了
+  - ファイル: 5つのRoute Handlers
   - 問題: `cache: 'no-store'`で毎回バックエンド呼び出し
-  - 工数: 1h
+  - 対応: `Cache-Control: private, max-age=10, stale-while-revalidate=30`を追加
+  - 適用ファイル: `tasks/all`, `tasks/ng`, `areas`, `comments`, `account/[id]/tasks`
+  - 完了日: 2025-12-27
 
 - [x] **PERF-004**: `styled-components`依存関係削除 ✅完了
   - ファイル: `package.json`
@@ -347,6 +349,7 @@
 | 2025-12-27 | TEST-004 | Cookie操作テスト追加 | Claude |
 | 2025-12-27 | PERF-004 | styled-components依存関係削除 | Claude |
 | 2025-12-27 | PERF-005 | MemberCardにmemo()追加 | Claude |
+| 2025-12-27 | PERF-003 | Route Handlersにキャッシュヘッダー追加 | Claude |
 
 ---
 

--- a/src/app/api/account/[id]/tasks/route.ts
+++ b/src/app/api/account/[id]/tasks/route.ts
@@ -41,7 +41,11 @@ export const GET = async (
 
     if (res.ok) {
       const result: Task[] = (await res.json()) as Task[];
-      return NextResponse.json(result);
+      return NextResponse.json(result, {
+        headers: {
+          'Cache-Control': 'private, max-age=10, stale-while-revalidate=30',
+        },
+      });
     } else {
       const errorText = await res.text().catch(() => '');
       return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });

--- a/src/app/api/areas/route.ts
+++ b/src/app/api/areas/route.ts
@@ -23,7 +23,11 @@ export const GET = async () => {
     });
     if (res.ok) {
       const result: Area[] = (await res.json()) as Area[];
-      return NextResponse.json(result);
+      return NextResponse.json(result, {
+        headers: {
+          'Cache-Control': 'private, max-age=10, stale-while-revalidate=30',
+        },
+      });
     } else {
       const errorText = await res.text().catch(() => '');
       return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -58,7 +58,11 @@ export const GET = async (request: NextRequest) => {
 
     if (res.ok) {
       const result: Comment[] = (await res.json()) as Comment[];
-      return NextResponse.json(result);
+      return NextResponse.json(result, {
+        headers: {
+          'Cache-Control': 'private, max-age=10, stale-while-revalidate=30',
+        },
+      });
     } else {
       const errorText = await res.text().catch(() => '');
       return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });

--- a/src/app/api/tasks/all/route.ts
+++ b/src/app/api/tasks/all/route.ts
@@ -24,7 +24,11 @@ export const GET = async () => {
 
     if (res.ok) {
       const result: Task[] = (await res.json()) as Task[];
-      return NextResponse.json(result);
+      return NextResponse.json(result, {
+        headers: {
+          'Cache-Control': 'private, max-age=10, stale-while-revalidate=30',
+        },
+      });
     } else {
       const errorText = await res.text().catch(() => '');
       return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });

--- a/src/app/api/tasks/ng/route.ts
+++ b/src/app/api/tasks/ng/route.ts
@@ -25,7 +25,11 @@ export const GET = async () => {
 
     if (res.ok) {
       const result: Task[] = (await res.json()) as Task[];
-      return NextResponse.json(result);
+      return NextResponse.json(result, {
+        headers: {
+          'Cache-Control': 'private, max-age=10, stale-while-revalidate=30',
+        },
+      });
     } else {
       const errorText = await res.text().catch(() => '');
       return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });


### PR DESCRIPTION
## Summary

- 5つのGET Route HandlersにCache-Controlヘッダーを追加
- クライアント側でのキャッシュによりバックエンドへのリクエストを削減

## Changes

| ファイル | 変更内容 |
|----------|----------|
| tasks/all/route.ts | Cache-Control追加 |
| tasks/ng/route.ts | Cache-Control追加 |
| areas/route.ts | Cache-Control追加 |
| comments/route.ts | Cache-Control追加 |
| account/[id]/tasks/route.ts | Cache-Control追加 |

## Cache Strategy

- private: ユーザー固有データのためCDNキャッシュ禁止
- max-age=10: 10秒間は新鮮なキャッシュとして利用
- stale-while-revalidate=30: 10〜40秒はstaleデータを返しつつバックグラウンド再検証

## Test plan

- npm test - Pass 356件
- npm run lint - ESLintエラーなし

## Related

- PERF-003 in TODO.md