### PR TITLE
fix: ダッシュボードのエラーハンドリング改善（CODE-013）

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -11,9 +11,9 @@
 |--------|------|------|------|
 | Critical | 2 | 2 | 0 |
 | High | 11 | 8 | 3 |
-| Medium | 16 | 14 | 2 |
+| Medium | 16 | 15 | 1 |
 | Low | 6 | 0 | 6 |
-| **合計** | **35** | **24** | **11** |
+| **合計** | **35** | **25** | **10** |
 
 ---
 
@@ -27,21 +27,6 @@
   - 備考: ECS Task Role、Amplify設定等のインフラ変更が必要。フロントエンドのみでは対応不可。
   - 工数: 4h（インフラ側作業）
   - 移動元: Critical（2025-12-26）
-
----
-
-## Medium（次スプリント対応）
-
-### コード品質
-
-- [ ] **CODE-013**: ダッシュボードのエラーハンドリング改善
-  - ファイル: `src/app/(admin)/dashboard/page.tsx`, `src/api/get-account-status.ts`, `src/api/get-unfulfilled-count.ts`
-  - 問題: API失敗時にサイレントフォールバック（空配列/0）でユーザー通知なし
-  - 対応案:
-    1. ダッシュボードページにエラーログ追加（logError使用）
-    2. get-account-status.ts, get-unfulfilled-count.tsにエラーログ追加（get-areas.tsと統一）
-    3. コンポーネントにエラー状態props追加でUI表示
-  - 工数: 2h
 
 ---
 
@@ -351,6 +336,15 @@
   - 対応: `{ message: string }`に厳格化
   - 完了日: 2025-12-27
 
+- [x] **CODE-013**: ダッシュボードのエラーハンドリング改善 ✅完了
+  - ファイル: `src/app/(admin)/dashboard/page.tsx`, `src/api/get-account-status.ts`, `src/api/get-unfulfilled-count.ts`, `src/components/Orders.tsx`, `src/components/Uncompletes.tsx`
+  - 問題: API失敗時にサイレントフォールバック（空配列/0）でユーザー通知なし
+  - 対応:
+    1. get-account-status.ts, get-unfulfilled-count.tsにlogError追加（get-areas.tsと統一）
+    2. dashboard/page.tsxでエラー状態を追跡しログ出力
+    3. Orders/Uncomletesにerror prop追加、エラー時はAlertコンポーネントで表示
+  - 完了日: 2025-12-27
+
 ### テスト
 
 - [x] **TEST-004**: Cookie操作テスト追加 ✅完了
@@ -390,3 +384,4 @@
 | 2025-12-27 | PERF-003 | Route Handlersにキャッシュヘッダー追加 | Claude |
 | 2025-12-27 | PERF-002 | ダッシュボードN+1クエリ解消 | Claude |
 | 2025-12-27 | PERF-006 | Orders/Uncomplete SWR移行（PERF-002で解決） | Claude |
+| 2025-12-27 | CODE-013 | ダッシュボードのエラーハンドリング改善 | Claude |

--- a/src/api/get-account-status.ts
+++ b/src/api/get-account-status.ts
@@ -3,6 +3,7 @@
 import { serverHttpClient } from '@/src/infra/http';
 import { MemberStatus, ApiResult, ErrorResponse } from '@/src/types';
 import { getCookies } from '@/src/util/cookies';
+import { logError } from '@/src/util/safe-logger';
 
 export async function getAccountStatus(): Promise<ApiResult<MemberStatus[]>> {
   const token = getCookies('token');
@@ -19,6 +20,7 @@ export async function getAccountStatus(): Promise<ApiResult<MemberStatus[]>> {
     return result.value;
   }
 
+  logError('[getAccountStatus]', result.error.message);
   const errorResponse: ErrorResponse = {
     errors: [result.error.message],
   };

--- a/src/api/get-unfulfilled-count.ts
+++ b/src/api/get-unfulfilled-count.ts
@@ -3,6 +3,7 @@
 import { serverHttpClient } from '@/src/infra/http';
 import { ApiResult, ErrorResponse } from '@/src/types';
 import { getCookies } from '@/src/util/cookies';
+import { logError } from '@/src/util/safe-logger';
 
 export async function getUnfulfilledCount(): Promise<ApiResult<number>> {
   const token = getCookies('token');
@@ -15,6 +16,7 @@ export async function getUnfulfilledCount(): Promise<ApiResult<number>> {
     return result.value;
   }
 
+  logError('[getUnfulfilledCount]', result.error.message);
   const errorResponse: ErrorResponse = {
     errors: [result.error.message],
   };

--- a/src/app/(admin)/dashboard/page.tsx
+++ b/src/app/(admin)/dashboard/page.tsx
@@ -16,6 +16,7 @@ import Uncompletes from '@/src/components/Uncompletes';
 import { formatDateToEnglish } from '@/src/domain/functions/date';
 import { getNow } from '@/src/infra/time';
 import { isErrorResponse, MemberStatus } from '@/src/types';
+import { logError } from '@/src/util/safe-logger';
 
 const Dashboard = async () => {
   // PERF-002: バッチ化 - 3つのAPIを並列で呼び出し
@@ -25,16 +26,25 @@ const Dashboard = async () => {
     getUnfulfilledCount(),
   ]);
 
-  const areaNames: string[] = isErrorResponse(areasResult)
-    ? []
-    : areasResult.map((area) => area.name);
+  // CODE-013: エラー状態を追跡してUIに反映
+  const areasError = isErrorResponse(areasResult);
+  const accountsError = isErrorResponse(accountsResult);
+  const unfulfilledError = isErrorResponse(unfulfilledResult);
 
-  const members: MemberStatus[] = isErrorResponse(accountsResult)
-    ? []
-    : accountsResult;
+  // エラー時はログ出力（API側でも出力されるが、ダッシュボード側でも集約ログとして出力）
+  if (areasError) {
+    logError('[Dashboard] areas取得失敗', areasResult.errors);
+  }
+  if (accountsError) {
+    logError('[Dashboard] accounts取得失敗', accountsResult.errors);
+  }
+  if (unfulfilledError) {
+    logError('[Dashboard] unfulfilled count取得失敗', unfulfilledResult.errors);
+  }
 
-  const unfulfilledCount: number =
-    typeof unfulfilledResult === 'number' ? unfulfilledResult : 0;
+  const areaNames: string[] = areasError ? [] : areasResult.map((area) => area.name);
+  const members: MemberStatus[] = accountsError ? [] : accountsResult;
+  const unfulfilledCount: number = unfulfilledError ? 0 : unfulfilledResult;
 
   const currentTime = formatDateToEnglish(getNow());
   return (
@@ -81,7 +91,11 @@ const Dashboard = async () => {
                   height: 240,
                 }}
               >
-                <Uncompletes count={unfulfilledCount} currentTime={currentTime} />
+                <Uncompletes
+                  count={unfulfilledCount}
+                  currentTime={currentTime}
+                  error={unfulfilledError}
+                />
               </Paper>
             </Grid>
             {/* Recent Orders */}
@@ -91,7 +105,7 @@ const Dashboard = async () => {
                 square={false}
                 sx={{ p: 2, display: 'flex', flexDirection: 'column' }}
               >
-                <Orders members={members} />
+                <Orders error={accountsError} members={members} />
               </Paper>
             </Grid>
           </Grid>

--- a/src/components/Orders.tsx
+++ b/src/components/Orders.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Table,
   TableBody,
   TableCell,
@@ -12,38 +13,45 @@ import { MemberStatus } from '@/src/types';
 
 type Props = {
   members: MemberStatus[];
+  error?: boolean;
 };
 
-const Orders = ({ members }: Props) => {
+const Orders = ({ members, error = false }: Props) => {
   return (
     <React.Fragment>
       <Title>Recent Orders</Title>
-      <Table size="small">
-        <TableHead>
-          <TableRow>
-            <TableCell>名前</TableCell>
-            <TableCell>エリア</TableCell>
-            <TableCell>総計</TableCell>
-            <TableCell>週間総計</TableCell>
-            <TableCell>NG率</TableCell>
-            <TableCell>現在アサイン</TableCell>
-            <TableCell align="right">遂行総計</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {members.map((row) => (
-            <TableRow key={row.id}>
-              <TableCell>{row.name}</TableCell>
-              <TableCell>{row.area.join(' ')}</TableCell>
-              <TableCell>{row.total}</TableCell>
-              <TableCell>{row.week}</TableCell>
-              <TableCell>{row.ng_rate}</TableCell>
-              <TableCell>{row.assign}</TableCell>
-              <TableCell align="right">{`${row.total}件`}</TableCell>
+      {error ? (
+        <Alert severity="error" sx={{ mt: 1 }}>
+          メンバー情報の取得に失敗しました。再読み込みしてください。
+        </Alert>
+      ) : (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>名前</TableCell>
+              <TableCell>エリア</TableCell>
+              <TableCell>総計</TableCell>
+              <TableCell>週間総計</TableCell>
+              <TableCell>NG率</TableCell>
+              <TableCell>現在アサイン</TableCell>
+              <TableCell align="right">遂行総計</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {members.map((row) => (
+              <TableRow key={row.id}>
+                <TableCell>{row.name}</TableCell>
+                <TableCell>{row.area.join(' ')}</TableCell>
+                <TableCell>{row.total}</TableCell>
+                <TableCell>{row.week}</TableCell>
+                <TableCell>{row.ng_rate}</TableCell>
+                <TableCell>{row.assign}</TableCell>
+                <TableCell align="right">{`${row.total}件`}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
     </React.Fragment>
   );
 };

--- a/src/components/Uncompletes.tsx
+++ b/src/components/Uncompletes.tsx
@@ -1,21 +1,28 @@
-import { Typography } from '@mui/material';
+import { Alert, Typography } from '@mui/material';
 import Link from '@mui/material/Link';
 import * as React from 'react';
 
 type Props = {
   count: number;
   currentTime: string;
+  error?: boolean;
 };
 
-const Uncompletes = ({ count, currentTime }: Props) => {
+const Uncompletes = ({ count, currentTime, error = false }: Props) => {
   return (
     <React.Fragment>
       <Typography component="p" sx={{ flex: 1 }} variant="h5">
         非達成件数
       </Typography>
-      <Typography component="p" sx={{ flex: 1 }} variant="h4">
-        {count}件
-      </Typography>
+      {error ? (
+        <Alert severity="error" sx={{ mt: 1, flex: 1 }}>
+          取得失敗
+        </Alert>
+      ) : (
+        <Typography component="p" sx={{ flex: 1 }} variant="h4">
+          {count}件
+        </Typography>
+      )}
       <Typography color="text.secondary" sx={{ flex: 1 }}>
         on {currentTime}
       </Typography>


### PR DESCRIPTION
## Summary
- API失敗時のサイレントフォールバックを解消
- エラー時のログ出力とUI表示を追加

## 変更内容
| ファイル | 変更 |
|----------|------|
| `get-account-status.ts` | logError追加 |
| `get-unfulfilled-count.ts` | logError追加 |
| `dashboard/page.tsx` | エラー状態追跡・ログ出力・error prop渡し |
| `Orders.tsx` | error prop追加、Alert表示 |
| `Uncompletes.tsx` | error prop追加、Alert表示 |

## Before/After
- **Before**: API失敗 → 空配列/0を表示（ユーザーに問題が伝わらない）
- **After**: API失敗 → Alertコンポーネントでエラーメッセージ表示 + ログ出力

## Test plan
- [x] `npm test` - 356件 Pass
- [x] `npm run lint` - Pass
- [ ] 手動確認: ネットワークエラー時にAlertが表示されること