### PR TITLE
fix: async Server Componentの警告をSuspenseで解消

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Box } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v14-appRouter';
+import { Suspense } from 'react';
 
 import Header from '@/src/components/Header';
 import { ToastContainer } from '@/src/components/Toast';
@@ -37,8 +38,10 @@ export default function RootLayout({
                   bgcolor: 'background.default',
                 }}
               >
-                <Header />
-                {children}
+                <Suspense fallback={null}>
+                  <Header />
+                </Suspense>
+                <Suspense fallback={null}>{children}</Suspense>
               </Box>
               <ToastContainer />
             </ToastProvider>


### PR DESCRIPTION
## Summary
- layout.tsxでHeaderとchildrenを`<Suspense fallback={null}>`でラップ
- MUI BoxコンポーネントへのReactNode prop警告を解消

## 問題
`/task`ページなどでコンソールに以下の警告が表示されていた：
```
Warning: Failed prop type: Invalid prop `children` supplied to `ForwardRef(Box)`, expected a ReactNode.
```

## 原因
async Server Component（Header, children）がClient Component（MUI Box）の直接の子として配置されると、Reactのprop-typesチェックが警告を発する。

## 解決策
Suspenseでasync Server Componentをラップし、Server/Client境界を明示。

## Test plan
- [x] `npm run lint` パス
- [x] `npm test` パス（356件）
- [ ] `/task`ページでコンソール警告が消えることを確認