### PR TITLE
docs: auth-check.tsにセキュリティ警告を追加（AUTH-H01）

### DIFF
--- a/src/util/auth-check.ts
+++ b/src/util/auth-check.ts
@@ -3,6 +3,13 @@
  * SEC-006: Route Handlersに認可チェック追加
  *
  * @server-only - これらの関数はServer Components/Route Handlersでのみ動作
+ *
+ * ⚠️ セキュリティ警告 ⚠️
+ * このモジュールの認可チェック（isAdminFromCookie）はCookie値に依存しており、
+ * クライアント側で改竄可能です。これはDefense in Depth（多層防御）の一層としてのみ使用し、
+ * 必ずバックエンドAPIでも認可チェックを実施してください。
+ *
+ * @see Rails側: app/controllers/concerns/authorization.rb
  */
 
 import { cookies } from 'next/headers';
@@ -30,11 +37,20 @@ export const isAuthenticated = (): boolean => {
 /**
  * 認可チェック: 管理者権限を確認
  *
- * 警告: この関数はCookieの値を信頼するため、フロントエンドのみの防御です。
- * Cookieはクライアント側で改竄可能なため、バックエンドでも必ず認可チェックを実施すること。
- * （Defense in Depth: 多層防御の原則）
+ * ⚠️ セキュリティ警告 ⚠️
+ * この関数はCookieの値を信頼するため、フロントエンドのみの防御です。
+ * Cookieはクライアント側で改竄可能なため、この関数だけで認可を判断してはいけません。
  *
- * @returns 管理者ロールの場合true
+ * 必須: バックエンドAPIでも必ず認可チェックを実施すること
+ * - Rails側: before_action :require_admin! を使用
+ * - JWTトークンからユーザーロールを検証
+ *
+ * 用途:
+ * - UI表示の制御（管理者メニューの表示/非表示）
+ * - 早期リターンによるUX向上（不正リクエストの事前ブロック）
+ *
+ * @security この関数はDefense in Depth（多層防御）の補助層としてのみ使用
+ * @returns 管理者ロールの場合true（Cookieが改竄されている可能性あり）
  */
 export const isAdminFromCookie = (): boolean => {
   try {


### PR DESCRIPTION
## Summary
- `isAdminFromCookie()`関数にセキュリティ警告を追加
- Cookie改竄リスクとバックエンド認可必須の明確化

## 変更内容

### モジュールレベル警告
```typescript
/**
 * ⚠️ セキュリティ警告 ⚠️
 * このモジュールの認可チェック（isAdminFromCookie）はCookie値に依存しており、
 * クライアント側で改竄可能です。これはDefense in Depth（多層防御）の一層としてのみ使用し、
 * 必ずバックエンドAPIでも認可チェックを実施してください。
 */
```

### 関数レベル警告
- Cookie改竄リスクの明確化
- バックエンド認可必須の明記（Rails側: `before_action :require_admin!`）
- 用途の明確化（UI制御、早期リターン）
- `@security` タグの追加

## 対象ファイル
- `src/util/auth-check.ts` - ドキュメントのみの変更

## Test plan
- [x] ESLint Pass
- [x] 機能変更なし（ドキュメントのみ）