### PR TITLE
fix: CommentListのany型を排除

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -42,13 +42,5 @@
         }
       }
     ]
-  },
-  "overrides": [
-    {
-      "files": ["src/components/CommentList.tsx"],
-      "rules": {
-        "@typescript-eslint/no-explicit-any": "off"
-      }
-    }
-  ]
+  }
 }

--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -11,10 +11,10 @@
 | 優先度 | 総数 | 完了 | 残り |
 |--------|------|------|------|
 | Critical | 2 | 2 | 0 |
-| High | 3 | 0 | 3 |
+| High | 3 | 2 | 1 |
 | Medium | 7 | 0 | 7 |
 | Low | 19 | 0 | 19 |
-| **合計** | **31** | **2** | **29** |
+| **合計** | **31** | **4** | **27** |
 
 ---
 
@@ -46,20 +46,19 @@
   - 備考: ECS Task Role、Amplify設定等のインフラ変更が必要。フロントエンドのみでは対応不可。
   - 工数: 4h（インフラ側作業）
 
-- [ ] **AUTH-H01**: フロントエンドロールチェックの警告追加（総合レビュー）
+- [x] **AUTH-H01**: フロントエンドロールチェックの警告追加 ✅完了
   - ファイル: `src/util/auth-check.ts`
-  - 問題: `isAdminFromCookie()`はCookie値に依存、クライアント側で改竄可能
-  - 対応: JSDocに明確な警告追加、バックエンド認可必須の旨を明記
-  - 備考: 現状はDefense in Depthとして機能、バックエンドでも認可チェック必須
-  - 工数: 0.5h
+  - 完了日: 2025-12-29
+  - 対応: JSDocに⚠️セキュリティ警告を追加、バックエンド認可必須の旨を明記
+  - PR: #114
 
 ### 型定義
 
-- [ ] **TYPE-H01**: CommentListのany型排除（総合レビュー）
+- [x] **TYPE-H01**: CommentListのany型排除 ✅完了
   - ファイル: `src/components/CommentList.tsx`, `.eslintrc.json`
-  - 問題: MUI DataGridで`any`型を許可するESLint override、型安全性低下
-  - 対応: GridRow/GridColumn型を定義、ESLint overrideを削除
-  - 工数: 1h
+  - 完了日: 2025-12-29
+  - 対応: CommentRow型を定義、ESLint overrideを削除
+  - PR: #115
 
 ---
 
@@ -275,6 +274,8 @@
 | 2025-12-28 | - | AreaListCheckサイレント失敗修正（PR #112 Critical） | Claude |
 | 2025-12-28 | - | CommentList楽観的UIロールバック追加（PR #112 Important） | Claude |
 | 2025-12-28 | FILE-C01 | ファイルアップロードバリデーション追加（PR #113） | Claude |
+| 2025-12-29 | AUTH-H01 | フロントエンドロールチェック警告追加（PR #114） | Claude |
+| 2025-12-29 | TYPE-H01 | CommentListのany型排除（PR #115） | Claude |
 
 ---
 

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -113,7 +113,7 @@ const createRows = (comments: Comment[]): CommentRow[] => {
     id: cur.id,
     name: cur.name,
     comment: cur.content,
-    joinDate: cur.updatedAt,
+    joinDate: new Date(cur.updatedAt),
     role: cur.role,
     isNew: false,
   }));

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -8,7 +8,6 @@ import SaveIcon from '@mui/icons-material/Save';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import {
-  GridRowsProp,
   GridRowModesModel,
   GridRowModes,
   DataGrid,
@@ -17,7 +16,6 @@ import {
   GridActionsCellItem,
   GridEventListener,
   GridRowId,
-  GridRowModel,
   GridRowEditStopReasons,
   GridSlots,
 } from '@mui/x-data-grid';
@@ -32,8 +30,21 @@ import { logError } from '@/src/util/safe-logger';
 import { AccountData } from '../types';
 import { Comment } from '../types';
 
+/**
+ * DataGridの行データ型
+ * MUI DataGridのGridRowModelの代わりに使用し、型安全性を確保
+ */
+interface CommentRow {
+  id: number;
+  name: string;
+  comment: string;
+  joinDate: Date;
+  role: string;
+  isNew: boolean;
+}
+
 interface EditToolbarProps {
-  setRows: (newRows: (oldRows: GridRowsProp) => GridRowsProp) => void;
+  setRows: (newRows: (oldRows: CommentRow[]) => CommentRow[]) => void;
   setRowModesModel: (
     newModel: (oldModel: GridRowModesModel) => GridRowModesModel,
   ) => void;
@@ -93,7 +104,7 @@ const EditToolbar = (props: EditToolbarProps) => {
  * @param comments - APIから取得したコメントの配列
  * @returns DataGridで使用可能な行データの配列
  */
-const createRows = (comments: Comment[]): GridRowsProp => {
+const createRows = (comments: Comment[]): CommentRow[] => {
   if (!Array.isArray(comments) || comments.length === 0) {
     return [];
   }
@@ -124,7 +135,7 @@ type Props = {
  * - flagNewComment: 新規コメントかどうかを追跡するフラグ（POST/PUTの判定に使用）
  */
 const CommentList = (props: Props) => {
-  const [rows, setRows] = React.useState(createRows(props.comments));
+  const [rows, setRows] = React.useState<CommentRow[]>(createRows(props.comments));
   const [rowModesModel, setRowModesModel] = React.useState<GridRowModesModel>(
     {},
   );
@@ -210,14 +221,14 @@ const CommentList = (props: Props) => {
    * @param updatedRow - 更新後の行データ（新規作成時にIDを更新するために使用）
    */
   const saveComment = useCallback(
-    (newRow: GridRowModel, updatedRow: GridRowModel) => {
+    (newRow: CommentRow, updatedRow: CommentRow) => {
       if (flagNewComment) {
         // 新規コメント作成
-        createComment(newRow.comment as string, props.cycleId)
+        createComment(newRow.comment, props.cycleId)
           .then((result) => {
             if (result.success && result.data) {
               const newId = result.data.id;
-              const newUpdatedRow = { ...updatedRow, id: newId };
+              const newUpdatedRow: CommentRow = { ...updatedRow, id: newId };
               setRows((currentRows) =>
                 currentRows.map((row) =>
                   row.id === newRow.id ? newUpdatedRow : row
@@ -235,7 +246,7 @@ const CommentList = (props: Props) => {
         setFlagNewComment(false);
       } else {
         // 既存コメント更新
-        updateComment(newRow.comment as string, newRow.id as number)
+        updateComment(newRow.comment, newRow.id)
           .then((result) => {
             if (result.success) {
               showSuccess('コメントを更新しました');
@@ -260,8 +271,8 @@ const CommentList = (props: Props) => {
    * @returns 更新後の行データ
    */
   const processRowUpdate = useCallback(
-    (newRow: GridRowModel) => {
-      const updatedRow = { ...newRow, isNew: false };
+    (newRow: CommentRow): CommentRow => {
+      const updatedRow: CommentRow = { ...newRow, isNew: false };
       setRows((currentRows) =>
         currentRows.map((row) => (row.id === newRow.id ? updatedRow : row))
       );

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -30,16 +30,21 @@ import { logError } from '@/src/util/safe-logger';
 import { AccountData } from '../types';
 import { Comment } from '../types';
 
+/** ユーザーロール型 */
+type UserRole = 'admin' | 'member';
+
 /**
- * DataGridの行データ型
- * MUI DataGridのGridRowModelの代わりに使用し、型安全性を確保
+ * コメント一覧DataGrid用の行データ型
+ * DataGridの行に表示するコメントデータの型を定義
  */
 interface CommentRow {
   id: number;
   name: string;
   comment: string;
+  /** コメントの最終更新日時（UIでは「Join date」として表示） */
   joinDate: Date;
-  role: string;
+  role: UserRole;
+  /** 新規追加行フラグ（true: 未保存の新規行, false: API取得済み or 保存済み） */
   isNew: boolean;
 }
 
@@ -48,7 +53,7 @@ interface EditToolbarProps {
   setRowModesModel: (
     newModel: (oldModel: GridRowModesModel) => GridRowModesModel,
   ) => void;
-  role: string;
+  role: UserRole;
   name: string;
 }
 
@@ -114,7 +119,7 @@ const createRows = (comments: Comment[]): CommentRow[] => {
     name: cur.name,
     comment: cur.content,
     joinDate: new Date(cur.updatedAt),
-    role: cur.role,
+    role: cur.role as UserRole,
     isNew: false,
   }));
 };
@@ -147,7 +152,7 @@ const CommentList = (props: Props) => {
   const { createComment, updateComment, deleteComment } = useCommentMutation();
   const { showSuccess, showError } = useToast();
 
-  const role: string = props.account.role;
+  const role = props.account.role as UserRole;
   const name: string = props.account.name;
 
   const handleRowEditStop: GridEventListener<'rowEditStop'> = useCallback((


### PR DESCRIPTION
## Summary

- TYPE-H01: CommentListコンポーネントのany型を排除し、型安全性を向上

## 変更内容

- `CommentRow` インターフェースを定義（DataGridの行データ用）
- `EditToolbarProps`, `createRows`, `processRowUpdate`等の型を明示化
- ESLintの `@typescript-eslint/no-explicit-any` overrideを削除
- 未使用の `GridRowsProp`, `GridRowModel` インポートを削除

## Test plan

- [x] npm run lint - パス確認
- [x] npm test - 678 tests パス

## 参照

- TODO.md: TYPE-H01
