### PR TITLE
fix: SEC-M01 HSTSヘッダー追加

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -12,9 +12,9 @@
 |--------|------|------|------|
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
-| Medium | 7 | 4 | 3 |
+| Medium | 7 | 5 | 2 |
 | Low | 19 | 0 | 19 |
-| **合計** | **31** | **8** | **23** |
+| **合計** | **31** | **9** | **22** |
 
 ---
 
@@ -102,11 +102,11 @@
 
 ### セキュリティ（総合レビュー）
 
-- [ ] **SEC-M01**: HSTSヘッダー追加
+- [x] **SEC-M01**: HSTSヘッダー追加 ✅完了
   - ファイル: `next.config.mjs`
-  - 問題: Strict-Transport-Securityヘッダー未設定
+  - 完了日: 2025-12-29
   - 対応: `Strict-Transport-Security: max-age=31536000; includeSubDomains`追加
-  - 工数: 0.5h
+  - PR: #118
 
 ### パフォーマンス（総合レビュー）
 
@@ -280,6 +280,7 @@
 | 2025-12-29 | TYPE-H01 | CommentListのany型排除（PR #115） | Claude |
 | 2025-12-29 | ERR-001 | res.text()エラーのログ追加（PR #116） | Claude |
 | 2025-12-29 | ERR-002 | JSONパースエラー分離（PR #117） | Claude |
+| 2025-12-29 | SEC-M01 | HSTSヘッダー追加（PR #118） | Claude |
 
 ---
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -25,6 +25,10 @@ const nextConfig = {
             key: 'Permissions-Policy',
             value: 'camera=(), microphone=(), geolocation=()',
           },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=31536000; includeSubDomains',
+          },
         ],
       },
     ];


### PR DESCRIPTION
## Summary

- `next.config.mjs`に`Strict-Transport-Security`ヘッダーを追加
- `max-age=31536000`（1年間）でHTTPS接続を強制
- `includeSubDomains`でサブドメインも対象

## 変更内容

| ファイル | 変更 |
|----------|------|
| `next.config.mjs` | HSTSヘッダー追加（+4行） |

## セキュリティ効果

- **ダウングレード攻撃防止**: HTTP→HTTPSへのリダイレクト時の中間者攻撃を防止
- **SSL Stripping攻撃防止**: ブラウザがHTTPS使用を記憶し、HTTP接続を自動的にHTTPSに変換
- **サブドメイン保護**: `includeSubDomains`により全サブドメインも保護対象

## Test plan

- [x] ESLint: Pass
- [x] Jest: 678 tests passed
- [ ] 本番環境でレスポンスヘッダーに`Strict-Transport-Security`が含まれることを確認

## 関連

- TODO: SEC-M01