### PR TITLE
refactor: CODE-019 validateId使用の統一

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -13,8 +13,8 @@
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
 | Medium | 7 | 7 | 0 |
-| Low | 23 | 3 | 20 |
-| **合計** | **35** | **14** | **21** |
+| Low | 23 | 4 | 19 |
+| **合計** | **35** | **15** | **20** |
 
 ---
 
@@ -214,12 +214,11 @@
   - 対応: 各ファイルの1行目 `'use server';` を削除
   - 工数: 0.5h
 
-- [ ] **CODE-019**: validateId使用の統一（PR #120 Suggestions）
+- [x] **CODE-019**: validateId使用の統一 ✅完了
   - ファイル: `src/app/api/comment/route.ts`
-  - 問題: DELETEハンドラで直接`validateId()`を使用し、`requireValidId()`ヘルパーを使っていない
-  - 対応: `requireValidId(commentIdParam ?? '')`に変更
-  - 備考: 現状でも動作に問題なし。コード一貫性の向上のため
-  - 工数: 0.5h
+  - 完了日: 2025-12-29
+  - 対応: DELETEハンドラで`requireValidId()`ヘルパーを使用するよう変更
+  - PR: #123
 
 ### ドキュメント
 

--- a/src/app/api/comment/route.ts
+++ b/src/app/api/comment/route.ts
@@ -4,9 +4,8 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { Comment, CommentApiResponse } from '@/src/types';
-import { requireAuth } from '@/src/util/route-helpers';
+import { requireAuth, requireValidId } from '@/src/util/route-helpers';
 import { logError } from '@/src/util/safe-logger';
-import { validateId } from '@/src/util/validation';
 
 type Body = {
   id: number;
@@ -168,14 +167,9 @@ export const DELETE = async (request: NextRequest) => {
   const searchParams = request.nextUrl.searchParams;
   const commentIdParam = searchParams.get('commentId');
 
-  // SEC-007: IDバリデーション（バウンドチェック含む）
-  const commentIdResult = validateId(commentIdParam);
-  if (!commentIdResult.valid) {
-    return NextResponse.json(
-      { errors: [commentIdResult.error] },
-      { status: 400 },
-    );
-  }
+  // CODE-019: requireValidId()ヘルパーを使用（SEC-007バリデーション + ログ出力）
+  const commentIdResult = requireValidId(commentIdParam ?? '');
+  if (!commentIdResult.ok) return commentIdResult.response;
   const commentId = commentIdResult.id;
 
   try {


### PR DESCRIPTION
## 概要

PR #120レビューで検出されたCODE-019を対応。`/api/comment` DELETEハンドラで直接`validateId()`を使用していた箇所を`requireValidId()`ヘルパーに変更。

## 変更内容

### `src/app/api/comment/route.ts`
- `requireValidId`をroute-helpersからインポート
- `validateId`インポートを削除（不要になったため）
- DELETEハンドラのバリデーション部分を`requireValidId()`に変更

**Before:**
```typescript
const commentIdResult = validateId(commentIdParam);
if (!commentIdResult.valid) {
  return NextResponse.json(
    { errors: [commentIdResult.error] },
    { status: 400 },
  );
}
const commentId = commentIdResult.id;
```

**After:**
```typescript
const commentIdResult = requireValidId(commentIdParam ?? '');
if (!commentIdResult.ok) return commentIdResult.response;
const commentId = commentIdResult.id;
```

### `docs/todo/TODO.md`
- CODE-019を完了としてマーク
- 進捗更新: Low 4/23完了、合計 15/35完了

## 変更理由

- 他のRoute Handlerと同じパターンに統一
- `requireValidId()`にはLOG-005で追加したログ出力も含まれるため、デバッグ時に有用
- コードの一貫性向上

## テスト結果

- ESLint: Pass
- Jest: 48 suites, 678 tests passed

## 関連

- 検出元: PR #120 Suggestions
- 依存: LOG-005（PR #122）で`requireValidId()`にログ出力を追加済み