### PR TITLE
refactor: TYPE-001 MutationResult型を判別共用体に変更

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -13,8 +13,8 @@
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
 | Medium | 7 | 7 | 0 |
-| Low | 23 | 5 | 18 |
-| **合計** | **35** | **16** | **19** |
+| Low | 23 | 6 | 17 |
+| **合計** | **35** | **17** | **18** |
 
 ---
 
@@ -131,11 +131,12 @@
 
 ### 型定義改善
 
-- [ ] **TYPE-001**: MutationResult型の判別共用体化
+- [x] **TYPE-001**: MutationResult型の判別共用体化 ✅完了
   - ファイル: `src/types/index.ts`
-  - 問題: 不正な状態を許容する型設計（`success: true`かつ`error`が存在可能）
+  - 完了日: 2025-12-29
   - 対応: `{ success: true; data: T } | { success: false; error: string }`に変更
-  - 工数: 2h（全使用箇所の修正含む）
+  - 修正箇所: 型定義、useTaskMutation、useAccountMutation、関連テスト
+  - PR: #125
 
 - [ ] **TYPE-002**: Task型とTaskDetail型の分離
   - ファイル: `src/types/index.ts`

--- a/src/__tests__/mutations/useAccountMutation.test.ts
+++ b/src/__tests__/mutations/useAccountMutation.test.ts
@@ -30,7 +30,8 @@ describe('useAccountMutation', () => {
         response = await result.current.deleteAccount(123);
       });
 
-      expect(response).toEqual({ success: true });
+      // TYPE-001: 判別共用体により、success: trueの場合はdataが必須
+      expect(response).toEqual({ success: true, data: undefined });
       expect(mockHttpClient.delete).toHaveBeenCalledWith('/api/account/123');
     });
 

--- a/src/__tests__/mutations/useTaskMutation.test.ts
+++ b/src/__tests__/mutations/useTaskMutation.test.ts
@@ -55,7 +55,8 @@ describe('useTaskMutation', () => {
         response = await result.current.completeTask(1, 'h1');
       });
 
-      expect(response).toEqual({ success: true });
+      // TYPE-001: 判別共用体により、success: trueの場合はdataが必須
+      expect(response).toEqual({ success: true, data: undefined });
       expect(mockHttpClient.put).toHaveBeenCalledWith('/api/task/h1/complete');
       expect(mockMutate).toHaveBeenCalledWith(
         expect.any(Function),
@@ -145,7 +146,8 @@ describe('useTaskMutation', () => {
         response = await result.current.markAsNG(1, 'h1');
       });
 
-      expect(response).toEqual({ success: true });
+      // TYPE-001: 判別共用体により、success: trueの場合はdataが必須
+      expect(response).toEqual({ success: true, data: undefined });
       expect(mockHttpClient.put).toHaveBeenCalledWith('/api/task/h1/ng');
     });
 
@@ -224,7 +226,8 @@ describe('useTaskMutation', () => {
         response = await result.current.reassign(1, 't1');
       });
 
-      expect(response).toEqual({ success: true });
+      // TYPE-001: 判別共用体により、success: trueの場合はdataが必須
+      expect(response).toEqual({ success: true, data: undefined });
       expect(mockHttpClient.put).toHaveBeenCalledWith('/api/task/t1/reassign');
     });
 

--- a/src/mutations/useAccountMutation.ts
+++ b/src/mutations/useAccountMutation.ts
@@ -20,7 +20,7 @@ export const useAccountMutation = () => {
         return { success: false, error: result.error.message };
       }
 
-      return { success: true };
+      return { success: true, data: undefined };
     },
     []
   );

--- a/src/mutations/useTaskMutation.ts
+++ b/src/mutations/useTaskMutation.ts
@@ -45,7 +45,7 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
             revalidate: false,
           },
         );
-        return { success: true };
+        return { success: true, data: undefined };
       } catch (e) {
         const message = e instanceof Error ? e.message : '完了処理に失敗しました';
         return { success: false, error: message };
@@ -82,7 +82,7 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
             revalidate: false,
           },
         );
-        return { success: true };
+        return { success: true, data: undefined };
       } catch (e) {
         const message = e instanceof Error ? e.message : 'NG処理に失敗しました';
         return { success: false, error: message };
@@ -121,7 +121,7 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
             revalidate: false,
           },
         );
-        return { success: true };
+        return { success: true, data: undefined };
       } catch (e) {
         const message =
           e instanceof Error ? e.message : '再アサイン処理に失敗しました';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -85,11 +85,21 @@ export type WeekCompleteData = {
 // CODE-003: 3箇所に重複定義されていた型を統合
 
 /**
- * Mutation操作の結果型
- * @template T - 成功時に返却されるデータの型（オプショナル）
+ * Mutation操作の結果型（判別共用体）
+ * TYPE-001: 不正な状態（success: true かつ error が存在）を型レベルで防止
+ *
+ * @template T - 成功時に返却されるデータの型（デフォルト: undefined）
+ *
+ * @example
+ * // データを返さない場合
+ * const result: MutationResult = { success: true, data: undefined };
+ * const error: MutationResult = { success: false, error: 'エラーメッセージ' };
+ *
+ * @example
+ * // データを返す場合
+ * const result: MutationResult<User> = { success: true, data: user };
+ * const error: MutationResult<User> = { success: false, error: 'エラーメッセージ' };
  */
-export type MutationResult<T = void> = {
-  success: boolean;
-  data?: T;
-  error?: string;
-};
+export type MutationResult<T = undefined> =
+  | { success: true; data: T }
+  | { success: false; error: string };


### PR DESCRIPTION
## 概要

`MutationResult<T>`型を判別共用体（Discriminated Union）に変更し、不正な状態を型レベルで防止。

## 変更内容

### `src/types/index.ts`

**Before:**
```typescript
export type MutationResult<T = void> = {
  success: boolean;
  data?: T;
  error?: string;
};
```

**After:**
```typescript
export type MutationResult<T = undefined> =
  | { success: true; data: T }
  | { success: false; error: string };
```

### Mutation Hooks

- `useTaskMutation.ts`: `{ success: true }` → `{ success: true, data: undefined }`
- `useAccountMutation.ts`: 同上

### テスト更新

- `useAccountMutation.test.ts`: 期待値に `data: undefined` を追加
- `useTaskMutation.test.ts`: 同上

## 変更理由

1. **不正な状態の防止**: `{ success: true, error: '...' }` のような矛盾した状態が型レベルで不可能に
2. **型絞り込みの有効化**: `if (result.success)` で `data` の存在が保証される
3. **コード品質向上**: 判別共用体パターンはTypeScriptのベストプラクティス

## 使用例

```typescript
const result = await deleteAccount(123);

if (result.success) {
  // ここでは result.data が T 型であることが保証される
  console.log('成功:', result.data);
} else {
  // ここでは result.error が string 型であることが保証される
  console.log('失敗:', result.error);
}
```

## テスト結果

- ESLint: Pass
- Jest: 48 suites, 678 tests passed

## 関連

- 検出元: PR #94 Suggestions