### PR TITLE
refactor: TYPE-002 Task型をバックエンドのPresenterに合わせて分離

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -13,8 +13,8 @@
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
 | Medium | 7 | 7 | 0 |
-| Low | 23 | 6 | 17 |
-| **合計** | **35** | **17** | **18** |
+| Low | 23 | 7 | 16 |
+| **合計** | **35** | **18** | **17** |
 
 ---
 
@@ -138,11 +138,12 @@
   - 修正箇所: 型定義、useTaskMutation、useAccountMutation、関連テスト
   - PR: #125
 
-- [ ] **TYPE-002**: Task型とTaskDetail型の分離
-  - ファイル: `src/types/index.ts`
+- [x] **TYPE-002**: Task型とTaskDetail型の分離 ✅完了
+  - ファイル: `src/types/index.ts`, `src/domain/schemas/index.ts`, `src/util/grouping.ts`
+  - 完了日: 2025-12-29
   - 問題: `render_task`は`history_id`/`assign_cycle_id`を返さない
-  - 対応: `TaskListItem`と`TaskDetail`型を新設
-  - 工数: 2h
+  - 対応: `BaseTask`, `TaskListItem`, `ActiveTask`, `TaskDetail`型を新設
+  - 備考: `Task`は後方互換性のため`TaskListItem`のエイリアスとして維持
 
 - [ ] **TYPE-003**: ValidationResult型の判別共用体化（PR #113 Suggestions）
   - ファイル: `src/mutations/useFileUpload.ts`

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -232,7 +232,8 @@ const CommentList = (props: Props) => {
         // 新規コメント作成
         createComment(newRow.comment, props.cycleId)
           .then((result) => {
-            if (result.success && result.data) {
+            if (result.success) {
+              // TYPE-001: 判別共用体により、success: trueの場合はdataが保証される
               const newId = result.data.id;
               const newUpdatedRow: CommentRow = { ...updatedRow, id: newId };
               setRows((currentRows) =>
@@ -242,7 +243,7 @@ const CommentList = (props: Props) => {
               );
               showSuccess('コメントを投稿しました');
             } else {
-              showError(result.error ?? 'コメントの投稿に失敗しました');
+              showError(result.error);
             }
           })
           .catch((e) => {

--- a/src/domain/schemas/index.ts
+++ b/src/domain/schemas/index.ts
@@ -5,17 +5,43 @@
 
 import { z } from 'zod';
 
-// Task型スキーマ
-export const TaskSchema = z.object({
+/**
+ * TYPE-002: Task型スキーマの分離
+ * バックエンドのPresenterごとに返却フィールドが異なる
+ */
+
+// BaseTask - 共通フィールド
+export const BaseTaskSchema = z.object({
   id: z.number(),
   task_title: z.string(),
   area_name: z.string(),
-  history_id: z.number(),
-  assign_cycle_id: z.number(),
   created_at: z.string(),
 });
 
-export const TaskArraySchema = z.array(TaskSchema);
+// TaskListItem - アサイン済みタスク一覧用（/account/tasks, /tasks?type=ng）
+export const TaskListItemSchema = BaseTaskSchema.extend({
+  history_id: z.number(),
+  assign_cycle_id: z.number(),
+});
+
+export const TaskListItemArraySchema = z.array(TaskListItemSchema);
+
+// ActiveTask - アクティブタスク一覧用（/tasks?type=all）
+export const ActiveTaskSchema = BaseTaskSchema.extend({
+  assign_cycle_id: z.number(),
+});
+
+export const ActiveTaskArraySchema = z.array(ActiveTaskSchema);
+
+// TaskDetail - タスク詳細用（show/create/update）
+export const TaskDetailSchema = BaseTaskSchema.extend({
+  area_id: z.number(),
+  updated_at: z.string(),
+});
+
+// 後方互換性のためのエイリアス
+export const TaskSchema = TaskListItemSchema;
+export const TaskArraySchema = TaskListItemArraySchema;
 
 // Comment型スキーマ
 export const CommentSchema = z.object({
@@ -72,7 +98,11 @@ export const ErrorResponseSchema = z.object({
 export const WeekCompleteDataSchema = z.record(z.string(), z.number());
 
 // 型推論用エクスポート
-export type TaskSchemaType = z.infer<typeof TaskSchema>;
+export type BaseTaskSchemaType = z.infer<typeof BaseTaskSchema>;
+export type TaskListItemSchemaType = z.infer<typeof TaskListItemSchema>;
+export type ActiveTaskSchemaType = z.infer<typeof ActiveTaskSchema>;
+export type TaskDetailSchemaType = z.infer<typeof TaskDetailSchema>;
+export type TaskSchemaType = z.infer<typeof TaskSchema>; // エイリアス
 export type CommentSchemaType = z.infer<typeof CommentSchema>;
 export type AccountDataSchemaType = z.infer<typeof AccountDataSchema>;
 export type AreaSchemaType = z.infer<typeof AreaSchema>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,61 @@
-export type Task = {
+/**
+ * TYPE-002: Task型の分離
+ *
+ * バックエンドのPresenterごとに返却フィールドが異なるため、
+ * フロントエンドでも型を分離してtype safetyを確保する。
+ *
+ * @see photo-in-backend/app/presenters/task_presenter.rb
+ */
+
+/**
+ * タスク共通フィールド（全レスポンスで共通）
+ */
+export type BaseTask = {
   id: number;
   task_title: string;
   area_name: string;
-  history_id: number;
-  assign_cycle_id: number;
   created_at: string;
 };
+
+/**
+ * アサイン済みタスク一覧用（メンバー/NGタスク一覧）
+ *
+ * @see render_account_assign_tasks - /account/tasks?id=X
+ * @see render_ng_tasks - /tasks?type=ng
+ */
+export type TaskListItem = BaseTask & {
+  history_id: number;
+  assign_cycle_id: number;
+};
+
+/**
+ * アクティブタスク一覧用（管理者の全タスク一覧）
+ * history_idは含まれない（アサインサイクルのみ）
+ *
+ * @see render_active_tasks - /tasks?type=all
+ */
+export type ActiveTask = BaseTask & {
+  assign_cycle_id: number;
+};
+
+/**
+ * タスク詳細/作成/更新レスポンス用
+ * history_id/assign_cycle_idは含まれない
+ *
+ * @see render_task - /tasks/:id (show/create/update)
+ */
+export type TaskDetail = BaseTask & {
+  area_id: number;
+  updated_at: string;
+};
+
+/**
+ * 後方互換性のためのエイリアス
+ * 新規コードではTaskListItemを使用すること
+ *
+ * @deprecated TaskListItemを使用
+ */
+export type Task = TaskListItem;
 
 export type Comment = {
   id: number;
@@ -47,8 +97,12 @@ export type ResponseStatus = {
   [key: string]: string;
 };
 
+/**
+ * タスクグルーピング結果型
+ * TaskListItem（アサイン済みタスク）のグルーピングに使用
+ */
 export type GroupType = {
-  [key: string]: Task[];
+  [key: string]: TaskListItem[];
 };
 
 export type GroupKey = 'time' | 'area';

--- a/src/util/grouping.ts
+++ b/src/util/grouping.ts
@@ -1,15 +1,17 @@
 import { toLocaleDateString } from '@/src/domain/functions/date';
 
-import { Task, GroupType, GroupKey } from '../types';
+import { TaskListItem, GroupType, GroupKey } from '../types';
 
 /**
  * タスクを日付またはエリアでグループ化する
+ * TYPE-002: TaskListItem（history_id, assign_cycle_id含む）を使用
+ *
  * @param items - グループ化するタスクの配列
  * @param groupKey - グループ化のキー ('time': 作成日でグループ化, 'area': エリアでグループ化)
  * @returns グループ化されたタスク（キー: 日付またはエリア名, 値: タスクの配列）
  */
-export const grouping = (items: Task[], groupKey: GroupKey): GroupType => {
-  return items.reduce((acc: GroupType, item: Task) => {
+export const grouping = (items: TaskListItem[], groupKey: GroupKey): GroupType => {
+  return items.reduce((acc: GroupType, item: TaskListItem) => {
     const key = groupKey === 'time'
       ? toLocaleDateString(new Date(item.created_at))
       : item.area_name;


### PR DESCRIPTION
## Summary
- バックエンドのPresenterごとに返却フィールドが異なるため、フロントエンドの型も分離
- `BaseTask`, `TaskListItem`, `ActiveTask`, `TaskDetail`型を新設
- `Task`は後方互換性のため`TaskListItem`のエイリアスとして維持

## 新規型定義

| 型 | 用途 | フィールド |
|---|---|---|
| `BaseTask` | 共通 | id, task_title, area_name, created_at |
| `TaskListItem` | アサイン済みタスク一覧 | BaseTask + history_id, assign_cycle_id |
| `ActiveTask` | アクティブタスク一覧 | BaseTask + assign_cycle_id |
| `TaskDetail` | タスク詳細 | BaseTask + area_id, updated_at |

## バックエンドとの対応

| バックエンドPresenter | フロントエンド型 |
|---|---|
| `render_account_assign_tasks` | `TaskListItem` |
| `render_ng_tasks` | `TaskListItem` |
| `render_active_tasks` | `ActiveTask` |
| `render_task` | `TaskDetail` |

## 変更ファイル
- `src/types/index.ts` - 型定義追加
- `src/domain/schemas/index.ts` - Zodスキーマ追加
- `src/util/grouping.ts` - TaskListItem明示使用

## Test plan
- [x] ESLint: Pass
- [x] Jest: Pass (48 suites, 678 tests)
- [x] 後方互換性: `Task`エイリアスで既存コード動作