### PR TITLE
refactor: TYPE-003/TYPE-004 ValidationResultとUploadResultを判別共用体に変更

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -13,8 +13,8 @@
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
 | Medium | 7 | 7 | 0 |
-| Low | 23 | 7 | 16 |
-| **合計** | **35** | **18** | **17** |
+| Low | 23 | 9 | 14 |
+| **合計** | **35** | **20** | **15** |
 
 ---
 
@@ -145,17 +145,17 @@
   - 対応: `BaseTask`, `TaskListItem`, `ActiveTask`, `TaskDetail`型を新設
   - 備考: `Task`は後方互換性のため`TaskListItem`のエイリアスとして維持
 
-- [ ] **TYPE-003**: ValidationResult型の判別共用体化（PR #113 Suggestions）
+- [x] **TYPE-003**: ValidationResult型の判別共用体化 ✅完了
   - ファイル: `src/mutations/useFileUpload.ts`
+  - 完了日: 2025-12-29
   - 問題: `valid`と`error`が独立したプロパティで不正状態を許容
   - 対応: `{ valid: true } | { valid: false; error: string }`に変更
-  - 工数: 0.5h
 
-- [ ] **TYPE-004**: UploadResult型の判別共用体化（PR #113 Suggestions）
+- [x] **TYPE-004**: UploadResult型の判別共用体化 ✅完了
   - ファイル: `src/mutations/useFileUpload.ts`
+  - 完了日: 2025-12-29
   - 問題: `success`と`error`が独立したプロパティで不正状態を許容
   - 対応: `{ success: true } | { success: false; error: string }`に変更
-  - 工数: 0.5h
 
 - [ ] **TYPE-005**: requireAdmin戻り値型の統一（PR #120 Suggestions）
   - ファイル: `src/util/route-helpers.ts`

--- a/src/mutations/useFileUpload.ts
+++ b/src/mutations/useFileUpload.ts
@@ -7,15 +7,21 @@ import { logError, logWarn } from '@/src/util/safe-logger';
 const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
 const ALLOWED_MIME_TYPES = ['application/pdf'];
 
-type UploadResult = {
-  success: boolean;
-  error?: string;
-};
+/**
+ * TYPE-004: アップロード結果型（判別共用体）
+ * 不正な状態（success: true かつ error が存在）を型レベルで防止
+ */
+type UploadResult =
+  | { success: true }
+  | { success: false; error: string };
 
-type ValidationResult = {
-  valid: boolean;
-  error?: string;
-};
+/**
+ * TYPE-003: バリデーション結果型（判別共用体）
+ * 不正な状態（valid: true かつ error が存在）を型レベルで防止
+ */
+type ValidationResult =
+  | { valid: true }
+  | { valid: false; error: string };
 
 /**
  * ファイルのバリデーションを実行


### PR DESCRIPTION
## Summary
- `ValidationResult`と`UploadResult`を判別共用体（Discriminated Union）に変更
- 不正な状態（valid: true かつ error 存在）を型レベルで防止

## 変更内容

### Before
```typescript
type ValidationResult = {
  valid: boolean;
  error?: string;  // valid: true でも error が存在可能
};

type UploadResult = {
  success: boolean;
  error?: string;  // success: true でも error が存在可能
};
```

### After
```typescript
type ValidationResult =
  | { valid: true }
  | { valid: false; error: string };

type UploadResult =
  | { success: true }
  | { success: false; error: string };
```

## 変更ファイル
- `src/mutations/useFileUpload.ts` - 型定義変更

## Test plan
- [x] ESLint: Pass
- [x] Jest: Pass (48 suites, 678 tests)