### PR TITLE
refactor: TYPE-005 requireAdmin戻り値型を判別共用体に変更

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -13,8 +13,8 @@
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
 | Medium | 7 | 7 | 0 |
-| Low | 23 | 9 | 14 |
-| **合計** | **35** | **20** | **15** |
+| Low | 23 | 10 | 13 |
+| **合計** | **35** | **21** | **14** |
 
 ---
 
@@ -157,12 +157,11 @@
   - 問題: `success`と`error`が独立したプロパティで不正状態を許容
   - 対応: `{ success: true } | { success: false; error: string }`に変更
 
-- [ ] **TYPE-005**: requireAdmin戻り値型の統一（PR #120 Suggestions）
+- [x] **TYPE-005**: requireAdmin戻り値型の統一 ✅完了
   - ファイル: `src/util/route-helpers.ts`
+  - 完了日: 2025-12-29
   - 問題: `requireAdmin()`が`null | NextResponse`を返し、他のヘルパー（`requireAuth`, `requireValidId`）の`{ ok: boolean }`パターンと不整合
   - 対応: `AdminResult = { ok: true } | { ok: false; response: NextResponse }` に変更
-  - 備考: 現状でも動作に問題なし。API一貫性の向上のため
-  - 工数: 0.5h
 
 ### ログ改善
 

--- a/src/app/api/account/[id]/route.ts
+++ b/src/app/api/account/[id]/route.ts
@@ -15,8 +15,8 @@ export const DELETE = async (
   const auth = requireAuth();
   if (!auth.ok) return auth.response;
 
-  const adminCheck = requireAdmin();
-  if (adminCheck) return adminCheck;
+  const adminResult = requireAdmin();
+  if (!adminResult.ok) return adminResult.response;
 
   const idResult = requireValidId(params.id);
   if (!idResult.ok) return idResult.response;

--- a/src/util/route-helpers.ts
+++ b/src/util/route-helpers.ts
@@ -56,23 +56,34 @@ export const requireAuth = (): AuthResult => {
 };
 
 /**
+ * TYPE-005: 管理者権限チェック結果の型（判別共用体）
+ * requireAuth, requireValidIdと同じパターンに統一
+ */
+type AdminResult =
+  | { ok: true }
+  | { ok: false; response: NextResponse };
+
+/**
  * 管理者権限チェック
  * 権限がない場合はNextResponseを返す
  *
  * @example
- * const adminCheck = requireAdmin();
- * if (adminCheck) return adminCheck;
+ * const adminResult = requireAdmin();
+ * if (!adminResult.ok) return adminResult.response;
  */
-export const requireAdmin = (): NextResponse | null => {
+export const requireAdmin = (): AdminResult => {
   if (!isAdminFromCookie()) {
     // LOG-004: 認可失敗ログ（セキュリティ監視用）
     logWarn('[requireAdmin]', '管理者権限が必要な操作への非管理者アクセス試行');
-    return NextResponse.json(
-      { errors: ['この操作には管理者権限が必要です'] },
-      { status: 403 },
-    );
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { errors: ['この操作には管理者権限が必要です'] },
+        { status: 403 },
+      ),
+    };
   }
-  return null;
+  return { ok: true };
 };
 
 /**


### PR DESCRIPTION
## Summary
- `requireAdmin()`の戻り値型を`NextResponse | null`から判別共用体`AdminResult`に変更
- `requireAuth`、`requireValidId`と同じパターンに統一

## 変更前
```typescript
const adminCheck = requireAdmin();
if (adminCheck) return adminCheck;
```

## 変更後
```typescript
const adminResult = requireAdmin();
if (!adminResult.ok) return adminResult.response;
```

## 変更ファイル
| ファイル | 変更内容 |
|----------|----------|
| `src/util/route-helpers.ts` | `AdminResult`型追加、`requireAdmin`戻り値型変更 |
| `src/app/api/account/[id]/route.ts` | 呼び出しパターン更新 |
| `docs/todo/TODO.md` | 進捗更新（21/35完了） |

## Test plan
- [x] ESLint: Pass
- [x] Jest: 48 suites, 678 tests Pass