### PR TITLE
fix: CODE-018 Route Handlerから不要な'use server'ディレクティブを削除

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -13,8 +13,8 @@
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
 | Medium | 7 | 7 | 0 |
-| Low | 23 | 10 | 13 |
-| **合計** | **35** | **21** | **14** |
+| Low | 23 | 11 | 12 |
+| **合計** | **35** | **22** | **13** |
 
 ---
 
@@ -210,11 +210,11 @@
   - 備考: 現状でも機能的には問題なし、UX改善として検討
   - 工数: 1h
 
-- [ ] **CODE-018**: 'use server'ディレクティブの削除
-  - ファイル: `src/app/api/{areas,tasks/all,tasks/ng}/route.ts`
+- [x] **CODE-018**: 'use server'ディレクティブの削除 ✅完了
+  - ファイル: `src/app/api/`配下の全Route Handler（11ファイル）
+  - 完了日: 2025-12-29
   - 問題: Route Handlerに不要なディレクティブ（Server Actions用）
   - 対応: 各ファイルの1行目 `'use server';` を削除
-  - 工数: 0.5h
 
 - [x] **CODE-019**: validateId使用の統一 ✅完了
   - ファイル: `src/app/api/comment/route.ts`

--- a/src/app/api/account/[id]/route.ts
+++ b/src/app/api/account/[id]/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';

--- a/src/app/api/account/[id]/tasks/route.ts
+++ b/src/app/api/account/[id]/tasks/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';

--- a/src/app/api/areas/route.ts
+++ b/src/app/api/areas/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';

--- a/src/app/api/aws/route.ts
+++ b/src/app/api/aws/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import {
   GetObjectCommand,
   GetObjectCommandInput,

--- a/src/app/api/comment/route.ts
+++ b/src/app/api/comment/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextRequest, NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';

--- a/src/app/api/comments/route.ts
+++ b/src/app/api/comments/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextRequest, NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';

--- a/src/app/api/task/[id]/complete/route.ts
+++ b/src/app/api/task/[id]/complete/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';

--- a/src/app/api/task/[id]/ng/route.ts
+++ b/src/app/api/task/[id]/ng/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';

--- a/src/app/api/task/[id]/reassign/route.ts
+++ b/src/app/api/task/[id]/reassign/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';

--- a/src/app/api/tasks/all/route.ts
+++ b/src/app/api/tasks/all/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';

--- a/src/app/api/tasks/ng/route.ts
+++ b/src/app/api/tasks/ng/route.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';


### PR DESCRIPTION
## Summary
- 全Route Handler（11ファイル）から不要な`'use server'`ディレクティブを削除
- `'use server'`はServer Actions専用であり、Route Handlerには不要

## 背景
- Route HandlerはNext.js App Routerでデフォルトでサーバーサイド実行される
- `'use server'`ディレクティブはServer Actions（クライアントから呼び出せる関数）専用
- 混乱を招く不要なコードの削除

## 変更ファイル（11ファイル）
- `src/app/api/areas/route.ts`
- `src/app/api/tasks/all/route.ts`
- `src/app/api/tasks/ng/route.ts`
- `src/app/api/comment/route.ts`
- `src/app/api/comments/route.ts`
- `src/app/api/account/[id]/route.ts`
- `src/app/api/account/[id]/tasks/route.ts`
- `src/app/api/aws/route.ts`
- `src/app/api/task/[id]/complete/route.ts`
- `src/app/api/task/[id]/ng/route.ts`
- `src/app/api/task/[id]/reassign/route.ts`

## Test plan
- [x] ESLint: Pass
- [x] Jest: 48 suites, 678 tests Pass

## 進捗
TODO.md: 22/35 完了