### PR TITLE
fix: エラーオブジェクト全体をログ出力（LOG-002）

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -13,8 +13,8 @@
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
 | Medium | 7 | 7 | 0 |
-| Low | 23 | 11 | 12 |
-| **合計** | **35** | **22** | **13** |
+| Low | 25 | 12 | 13 |
+| **合計** | **37** | **23** | **14** |
 
 ---
 
@@ -163,6 +163,13 @@
   - 問題: `requireAdmin()`が`null | NextResponse`を返し、他のヘルパー（`requireAuth`, `requireValidId`）の`{ ok: boolean }`パターンと不整合
   - 対応: `AdminResult = { ok: true } | { ok: false; response: NextResponse }` に変更
 
+- [ ] **TYPE-006**: MutationResultでフルエラーオブジェクト保持
+  - ファイル: `src/types/index.ts`, `src/mutations/*.ts`
+  - 問題: `MutationResult.error`が`string`型のため、mutation層でエラー情報（type, status）が消失
+  - 対応: `error: string`を`error: DomainError | string`に変更、またはerrorCode追加を検討
+  - 出典: PR #130 レビュー
+  - 工数: 2h
+
 ### ログ改善
 
 - [x] **LOG-001**: 認証失敗ログ追加 ✅完了
@@ -183,17 +190,24 @@
   - 対応: `logDebug('[requireValidId]', 'IDバリデーション失敗: ...')` を追加（デバッグレベル）
   - PR: #122
 
-- [ ] **LOG-002**: エラーオブジェクト全体をログ出力
-  - ファイル: 複数ファイル
+- [x] **LOG-002**: エラーオブジェクト全体をログ出力 ✅完了
+  - ファイル: `src/api/*.ts`（8ファイル）、`src/mutations/*.ts`（2ファイル）
+  - 完了日: 2025-12-30
   - 問題: `result.error.message`のみでフルオブジェクトが消失
-  - 対応: `logError(ctx, result.error)`に変更
-  - 工数: 1h
+  - 対応: `logError(ctx, result.error)`に変更（12箇所）
 
 - [ ] **LOG-003**: ログコンテキスト形式の統一
   - ファイル: 複数ファイル
   - 問題: `[postLogin]`と`[Middleware] レート制限`で形式が異なる
   - 対応: `[Category:function]`形式に統一
   - 工数: 1h
+
+- [ ] **LOG-006**: get-week-complete.tsにエラーログ追加
+  - ファイル: `src/api/get-week-complete.ts`
+  - 問題: エラー時に`logError()`を呼ばずに`ErrorResponse`を返却
+  - 対応: `logError('[getWeekComplete]', result.error)`を追加
+  - 出典: PR #130 レビュー
+  - 工数: 0.5h
 
 ### コード品質
 
@@ -292,6 +306,7 @@
 | TYPE-003, TYPE-004 | PR #113 Suggestions | Low |
 | LOG-001, LOG-004 | PR #120 Important | Low |
 | TYPE-005, LOG-005, CODE-019 | PR #120 Suggestions | Low |
+| TYPE-006, LOG-006 | PR #130 Suggestions | Low |
 
 ---
 
@@ -313,6 +328,7 @@
 | 2025-12-29 | PERF-M01 | 大規模リストコンポーネントのmemo化（PR #119） | Claude |
 | 2025-12-29 | DRY-M01 | Route Handler認証パターン共通化（PR #120） | Claude |
 | 2025-12-29 | LOG-001, LOG-004 | 認証・認可失敗ログ追加（PR #121） | Claude |
+| 2025-12-30 | LOG-002 | エラーオブジェクト全体をログ出力 | Claude |
 
 ---
 

--- a/src/__tests__/api/post-login.test.ts
+++ b/src/__tests__/api/post-login.test.ts
@@ -163,7 +163,11 @@ describe('postLogin', () => {
 
       await postLogin('user', 'pass');
 
-      expect(mockLogError).toHaveBeenCalledWith('[postLogin]', '認証エラー');
+      expect(mockLogError).toHaveBeenCalledWith('[postLogin]', {
+        type: 'api',
+        status: 401,
+        message: '認証エラー',
+      });
     });
 
     test('400エラー時もErrorResponseを返す', async () => {
@@ -233,7 +237,10 @@ describe('postLogin', () => {
 
       await postLogin('user', 'pass');
 
-      expect(mockLogError).toHaveBeenCalledWith('[postLogin]', 'タイムアウト');
+      expect(mockLogError).toHaveBeenCalledWith('[postLogin]', {
+        type: 'network',
+        message: 'タイムアウト',
+      });
     });
   });
 

--- a/src/__tests__/api/post-signup.test.ts
+++ b/src/__tests__/api/post-signup.test.ts
@@ -176,7 +176,11 @@ describe('postSignup', () => {
 
       await postSignup('user', 'pass', [], 'member', 5);
 
-      expect(mockLogError).toHaveBeenCalledWith('[postSignup]', 'バリデーションエラー');
+      expect(mockLogError).toHaveBeenCalledWith('[postSignup]', {
+        type: 'api',
+        status: 400,
+        message: 'バリデーションエラー',
+      });
     });
 
     test('422エラー（バリデーションエラー）時もErrorResponseを返す', async () => {
@@ -246,7 +250,10 @@ describe('postSignup', () => {
 
       await postSignup('user', 'pass', ['東京'], 'member', 5);
 
-      expect(mockLogError).toHaveBeenCalledWith('[postSignup]', 'タイムアウト');
+      expect(mockLogError).toHaveBeenCalledWith('[postSignup]', {
+        type: 'network',
+        message: 'タイムアウト',
+      });
     });
   });
 

--- a/src/api/get-account-status.ts
+++ b/src/api/get-account-status.ts
@@ -21,7 +21,7 @@ export async function getAccountStatus(): Promise<ApiResult<MemberStatus[]>> {
     return result.value;
   }
 
-  logError('[getAccountStatus]', result.error.message);
+  logError('[getAccountStatus]', result.error);
   const errorResponse: ErrorResponse = {
     errors: [result.error.message],
   };

--- a/src/api/get-account-tasks.ts
+++ b/src/api/get-account-tasks.ts
@@ -17,6 +17,6 @@ export const getAccountTasks = async (
   if (result.ok) {
     return result.value;
   }
-  logError('[getAccountTasks]', result.error.message);
+  logError('[getAccountTasks]', result.error);
   return { errors: [result.error.message] };
 };

--- a/src/api/get-areas.ts
+++ b/src/api/get-areas.ts
@@ -14,6 +14,6 @@ export const getAreas = async (): Promise<Area[] | ErrorResponse> => {
   if (result.ok) {
     return result.value;
   }
-  logError('[getAreas]', result.error.message);
+  logError('[getAreas]', result.error);
   return { errors: [result.error.message] };
 };

--- a/src/api/get-tasks.ts
+++ b/src/api/get-tasks.ts
@@ -15,6 +15,6 @@ export async function getTasks(): Promise<Task[] | ErrorResponse> {
   if (result.ok) {
     return result.value;
   }
-  logError('[getTasks]', result.error.message);
+  logError('[getTasks]', result.error);
   return { errors: [result.error.message] };
 }

--- a/src/api/get-unfulfilled-count.ts
+++ b/src/api/get-unfulfilled-count.ts
@@ -16,7 +16,7 @@ export async function getUnfulfilledCount(): Promise<ApiResult<number>> {
     return result.value;
   }
 
-  logError('[getUnfulfilledCount]', result.error.message);
+  logError('[getUnfulfilledCount]', result.error);
   const errorResponse: ErrorResponse = {
     errors: [result.error.message],
   };

--- a/src/api/post-login.ts
+++ b/src/api/post-login.ts
@@ -29,6 +29,6 @@ export async function postLogin(
   if (result.ok) {
     return result.value.account;
   }
-  logError('[postLogin]', result.error.message);
+  logError('[postLogin]', result.error);
   return { errors: [result.error.message] };
 }

--- a/src/api/post-signup.ts
+++ b/src/api/post-signup.ts
@@ -29,6 +29,6 @@ export const postSignup = async (
   if (result.ok) {
     return result.value;
   }
-  logError('[postSignup]', result.error.message);
+  logError('[postSignup]', result.error);
   return { errors: [result.error.message] };
 };

--- a/src/api/post-task-create.ts
+++ b/src/api/post-task-create.ts
@@ -21,7 +21,7 @@ const postTaskCreate = async (
   if (result.ok) {
     return result.value;
   }
-  logError('[postTaskCreate]', result.error.message);
+  logError('[postTaskCreate]', result.error);
   return { errors: [result.error.message] };
 };
 

--- a/src/mutations/useAccountMutation.ts
+++ b/src/mutations/useAccountMutation.ts
@@ -16,7 +16,7 @@ export const useAccountMutation = () => {
       const result = await httpClient.delete(`/api/account/${accountId}`);
 
       if (!result.ok) {
-        logError('[deleteAccount]', result.error.message);
+        logError('[deleteAccount]', result.error);
         return { success: false, error: result.error.message };
       }
 

--- a/src/mutations/useCommentMutation.ts
+++ b/src/mutations/useCommentMutation.ts
@@ -24,7 +24,7 @@ export const useCommentMutation = () => {
       });
 
       if (!result.ok) {
-        logError('[createComment]', result.error.message);
+        logError('[createComment]', result.error);
         return { success: false, error: result.error.message };
       }
 
@@ -44,7 +44,7 @@ export const useCommentMutation = () => {
       });
 
       if (!result.ok) {
-        logError('[updateComment]', result.error.message);
+        logError('[updateComment]', result.error);
         return { success: false, error: result.error.message };
       }
 
@@ -63,7 +63,7 @@ export const useCommentMutation = () => {
       );
 
       if (!result.ok) {
-        logError('[deleteComment]', result.error.message);
+        logError('[deleteComment]', result.error);
         return { success: false, error: result.error.message };
       }
 


### PR DESCRIPTION
## Summary
- `logError()`の第2引数を`result.error.message`から`result.error`に変更
- エラーオブジェクト全体をログ出力することで、スタックトレースやエラータイプ等の情報を保持
- 関連テストをフルエラーオブジェクトの検証に更新

## 変更ファイル
### 実装（12箇所）
- `src/api/post-login.ts`
- `src/api/get-unfulfilled-count.ts`
- `src/api/get-account-tasks.ts`
- `src/api/post-task-create.ts`
- `src/api/get-account-status.ts`
- `src/api/get-areas.ts`
- `src/api/get-tasks.ts`
- `src/api/post-signup.ts`
- `src/mutations/useAccountMutation.ts`
- `src/mutations/useCommentMutation.ts`（3箇所）

### テスト（4箇所）
- `src/__tests__/api/post-login.test.ts`
- `src/__tests__/api/post-signup.test.ts`

### ドキュメント
- `docs/todo/TODO.md` - 進捗更新（23/35完了）

## Test plan
- [x] `npm test` 全678件パス
- [x] `npx eslint` エラーなし
- [x] ログ出力がフルエラーオブジェクトになることを確認