### PR TITLE
fix: get-week-complete.tsにエラーログ追加（LOG-006）

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -13,8 +13,8 @@
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
 | Medium | 7 | 7 | 0 |
-| Low | 25 | 12 | 13 |
-| **合計** | **37** | **23** | **14** |
+| Low | 25 | 13 | 12 |
+| **合計** | **37** | **24** | **13** |
 
 ---
 
@@ -202,12 +202,12 @@
   - 対応: `[Category:function]`形式に統一
   - 工数: 1h
 
-- [ ] **LOG-006**: get-week-complete.tsにエラーログ追加
+- [x] **LOG-006**: get-week-complete.tsにエラーログ追加 ✅完了
   - ファイル: `src/api/get-week-complete.ts`
+  - 完了日: 2025-12-30
   - 問題: エラー時に`logError()`を呼ばずに`ErrorResponse`を返却
   - 対応: `logError('[getWeekComplete]', result.error)`を追加
   - 出典: PR #130 レビュー
-  - 工数: 0.5h
 
 ### コード品質
 
@@ -329,6 +329,7 @@
 | 2025-12-29 | DRY-M01 | Route Handler認証パターン共通化（PR #120） | Claude |
 | 2025-12-29 | LOG-001, LOG-004 | 認証・認可失敗ログ追加（PR #121） | Claude |
 | 2025-12-30 | LOG-002 | エラーオブジェクト全体をログ出力 | Claude |
+| 2025-12-30 | LOG-006 | get-week-complete.tsにエラーログ追加 | Claude |
 
 ---
 

--- a/src/api/get-week-complete.ts
+++ b/src/api/get-week-complete.ts
@@ -3,6 +3,7 @@
 import { serverHttpClient } from '@/src/infra/http';
 import { WeekCompleteData, ApiResult, ErrorResponse } from '@/src/types';
 import { getCookies } from '@/src/util/cookies';
+import { logError } from '@/src/util/safe-logger';
 
 export async function getWeekComplete(): Promise<ApiResult<WeekCompleteData>> {
   const token = getCookies('token');
@@ -15,6 +16,7 @@ export async function getWeekComplete(): Promise<ApiResult<WeekCompleteData>> {
     return result.value;
   }
 
+  logError('[getWeekComplete]', result.error);
   const errorResponse: ErrorResponse = {
     errors: [result.error.message],
   };


### PR DESCRIPTION
## Summary
- `src/api/get-week-complete.ts`にエラーログ追加
- PR #130 レビューで指摘された箇所の対応

## 変更内容
- `logError`をインポート追加
- エラー時に`logError('[getWeekComplete]', result.error)`を追加

## Test plan
- [x] `npm test` 全678件パス
- [x] `npx eslint` エラーなし