### PR TITLE
fix: 認証エラーの区別を実装（AUTH-001）

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -13,8 +13,8 @@
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
 | Medium | 7 | 7 | 0 |
-| Low | 25 | 13 | 12 |
-| **合計** | **37** | **24** | **13** |
+| Low | 25 | 14 | 11 |
+| **合計** | **37** | **25** | **12** |
 
 ---
 
@@ -211,11 +211,11 @@
 
 ### コード品質
 
-- [ ] **AUTH-001**: 認証エラーの区別
-  - ファイル: Route Handlers
+- [x] **AUTH-001**: 認証エラーの区別 ✅完了
+  - ファイル: `src/util/route-helpers.ts`
+  - 完了日: 2025-12-30
   - 問題: `cookie_error`と`no_token`が同一扱い
-  - 対応: ステータスコード分岐（500/401）
-  - 工数: 1h
+  - 対応: `cookie_error`→500、`no_token`→401に分岐
 
 - [ ] **ERR-L01**: AreaListCheckの広範なcatchブロック改善（PR #112）
   - ファイル: `src/components/AreaListCheck.tsx`
@@ -330,6 +330,7 @@
 | 2025-12-29 | LOG-001, LOG-004 | 認証・認可失敗ログ追加（PR #121） | Claude |
 | 2025-12-30 | LOG-002 | エラーオブジェクト全体をログ出力 | Claude |
 | 2025-12-30 | LOG-006 | get-week-complete.tsにエラーログ追加 | Claude |
+| 2025-12-30 | AUTH-001 | 認証エラーの区別（cookie_error→500, no_token→401） | Claude |
 
 ---
 

--- a/src/util/route-helpers.ts
+++ b/src/util/route-helpers.ts
@@ -41,8 +41,20 @@ export const requireAuth = (): AuthResult => {
 
   const authResult = getAuthHeaders();
   if (!authResult.ok) {
-    // LOG-001: 認証ヘッダー取得失敗ログ
-    logWarn('[requireAuth]', `認証ヘッダー取得失敗: ${authResult.reason}`);
+    // AUTH-001: cookie_errorとno_tokenを区別
+    if (authResult.reason === 'cookie_error') {
+      // Cookie取得でエラー発生 → サーバー側の問題
+      logWarn('[requireAuth]', '認証ヘッダー取得失敗: Cookie取得エラー');
+      return {
+        ok: false,
+        response: NextResponse.json(
+          { errors: ['サーバーエラーが発生しました'] },
+          { status: 500 },
+        ),
+      };
+    }
+    // no_token → 通常の認証エラー
+    logWarn('[requireAuth]', '認証ヘッダー取得失敗: トークンなし');
     return {
       ok: false,
       response: NextResponse.json(


### PR DESCRIPTION
## Summary
- `requireAuth()`で`cookie_error`と`no_token`を区別してステータスコードを分岐
- Cookie取得エラー（サーバー側問題）→ 500
- トークンなし（認証エラー）→ 401

## 変更前
```typescript
if (!authResult.ok) {
  return { status: 401 };  // 両方401
}
```

## 変更後
```typescript
if (!authResult.ok) {
  if (authResult.reason === 'cookie_error') {
    return { status: 500 };  // サーバーエラー
  }
  return { status: 401 };  // 認証エラー
}
```

## Test plan
- [x] `npm test` 全678件パス
- [x] `npx eslint` エラーなし