### PR TITLE
fix: ログコンテキスト形式を統一（LOG-003）

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -13,8 +13,8 @@
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
 | Medium | 7 | 7 | 0 |
-| Low | 25 | 14 | 11 |
-| **合計** | **37** | **25** | **12** |
+| Low | 25 | 15 | 10 |
+| **合計** | **37** | **26** | **11** |
 
 ---
 
@@ -196,11 +196,11 @@
   - 問題: `result.error.message`のみでフルオブジェクトが消失
   - 対応: `logError(ctx, result.error)`に変更（12箇所）
 
-- [ ] **LOG-003**: ログコンテキスト形式の統一
-  - ファイル: 複数ファイル
-  - 問題: `[postLogin]`と`[Middleware] レート制限`で形式が異なる
-  - 対応: `[Category:function]`形式に統一
-  - 工数: 1h
+- [x] **LOG-003**: ログコンテキスト形式の統一 ✅完了
+  - ファイル: `src/middleware.ts`, `src/app/(admin)/dashboard/page.tsx`
+  - 完了日: 2025-12-30
+  - 問題: `[Middleware] レート制限`等の日本語説明が不統一
+  - 対応: `[Category:function]`形式に統一（5箇所）
 
 - [x] **LOG-006**: get-week-complete.tsにエラーログ追加 ✅完了
   - ファイル: `src/api/get-week-complete.ts`
@@ -331,6 +331,7 @@
 | 2025-12-30 | LOG-002 | エラーオブジェクト全体をログ出力 | Claude |
 | 2025-12-30 | LOG-006 | get-week-complete.tsにエラーログ追加 | Claude |
 | 2025-12-30 | AUTH-001 | 認証エラーの区別（cookie_error→500, no_token→401） | Claude |
+| 2025-12-30 | LOG-003 | ログコンテキスト形式の統一 | Claude |
 
 ---
 

--- a/src/app/(admin)/dashboard/page.tsx
+++ b/src/app/(admin)/dashboard/page.tsx
@@ -33,13 +33,13 @@ const Dashboard = async () => {
 
   // エラー時はログ出力（API側でも出力されるが、ダッシュボード側でも集約ログとして出力）
   if (areasError) {
-    logError('[Dashboard] areas取得失敗', areasResult.errors);
+    logError('[Dashboard:getAreas]', areasResult.errors);
   }
   if (accountsError) {
-    logError('[Dashboard] accounts取得失敗', accountsResult.errors);
+    logError('[Dashboard:getAccounts]', accountsResult.errors);
   }
   if (unfulfilledError) {
-    logError('[Dashboard] unfulfilled count取得失敗', unfulfilledResult.errors);
+    logError('[Dashboard:getUnfulfilledCount]', unfulfilledResult.errors);
   }
 
   const areaNames: string[] = areasError ? [] : areasResult.map((area) => area.name);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,7 +35,7 @@ const cleanupStore = () => {
     }
   } catch (error) {
     // クリーンアップ失敗時はログのみ（次回クリーンアップで再試行）
-    logError('[Middleware] クリーンアップ', error);
+    logError('[Middleware:cleanupStore]', error);
   }
 };
 
@@ -163,7 +163,7 @@ export function middleware(request: NextRequest) {
   } catch (error) {
     // レート制限エラー時はリクエストを通す（Fail Open: 可用性優先）
     // セキュリティ優先の場合は500を返すよう変更可能
-    logError('[Middleware] レート制限', error);
+    logError('[Middleware:checkRateLimit]', error);
     return NextResponse.next();
   }
 }


### PR DESCRIPTION
## Summary
- 日本語説明を`[Category:function]`形式に統一（5箇所）
- ログ解析時の検索・フィルタリングが容易に

## 変更内容
| Before | After |
|--------|-------|
| `[Middleware] クリーンアップ` | `[Middleware:cleanupStore]` |
| `[Middleware] レート制限` | `[Middleware:checkRateLimit]` |
| `[Dashboard] areas取得失敗` | `[Dashboard:getAreas]` |
| `[Dashboard] accounts取得失敗` | `[Dashboard:getAccounts]` |
| `[Dashboard] unfulfilled count取得失敗` | `[Dashboard:getUnfulfilledCount]` |

## Test plan
- [x] `npm test` 全678件パス
- [x] `npx eslint` エラーなし