### PR TITLE
fix: TYPE-006 MutationResultでフルエラーオブジェクト保持

### DIFF
--- a/docs/todo/TODO.md
+++ b/docs/todo/TODO.md
@@ -13,8 +13,8 @@
 | Critical | 2 | 2 | 0 |
 | High | 3 | 2 | 1 |
 | Medium | 7 | 7 | 0 |
-| Low | 25 | 17 | 8 |
-| **合計** | **37** | **28** | **9** |
+| Low | 25 | 18 | 7 |
+| **合計** | **37** | **29** | **8** |
 
 ---
 
@@ -163,12 +163,13 @@
   - 問題: `requireAdmin()`が`null | NextResponse`を返し、他のヘルパー（`requireAuth`, `requireValidId`）の`{ ok: boolean }`パターンと不整合
   - 対応: `AdminResult = { ok: true } | { ok: false; response: NextResponse }` に変更
 
-- [ ] **TYPE-006**: MutationResultでフルエラーオブジェクト保持
+- [x] **TYPE-006**: MutationResultでフルエラーオブジェクト保持 ✅完了
   - ファイル: `src/types/index.ts`, `src/mutations/*.ts`
+  - 完了日: 2025-12-30
   - 問題: `MutationResult.error`が`string`型のため、mutation層でエラー情報（type, status）が消失
-  - 対応: `error: string`を`error: DomainError | string`に変更、またはerrorCode追加を検討
+  - 対応: `MutationErrorType`型を追加、`errorType?: 'api' | 'network' | 'validation'`と`statusCode?: number`フィールドを追加
+  - 修正箇所: 型定義、useTaskMutation、useAccountMutation、useCommentMutation、関連テスト
   - 出典: PR #130 レビュー
-  - 工数: 2h
 
 ### ログ改善
 
@@ -333,6 +334,7 @@
 | 2025-12-30 | LOG-003 | ログコンテキスト形式の統一 | Claude |
 | 2025-12-30 | FEAT-001 | 404 Not Found ページ作成 | Claude |
 | 2025-12-30 | ERR-L01 | AreaListCheckの広範なcatchブロック改善 | Claude |
+| 2025-12-30 | TYPE-006 | MutationResultでフルエラーオブジェクト保持 | Claude |
 
 ---
 

--- a/src/__tests__/mutations/useAccountMutation.test.ts
+++ b/src/__tests__/mutations/useAccountMutation.test.ts
@@ -35,7 +35,7 @@ describe('useAccountMutation', () => {
       expect(mockHttpClient.delete).toHaveBeenCalledWith('/api/account/123');
     });
 
-    test('returns error result on failure', async () => {
+    test('returns error result with errorType and statusCode on API failure', async () => {
       mockHttpClient.delete.mockResolvedValueOnce({
         ok: false,
         error: { type: 'api', status: 404, message: 'Account not found' },
@@ -48,10 +48,16 @@ describe('useAccountMutation', () => {
         response = await result.current.deleteAccount(999);
       });
 
-      expect(response).toEqual({ success: false, error: 'Account not found' });
+      // TYPE-006: エラー時にerrorType, statusCodeを保持
+      expect(response).toEqual({
+        success: false,
+        error: 'Account not found',
+        errorType: 'api',
+        statusCode: 404,
+      });
     });
 
-    test('returns error result on forbidden', async () => {
+    test('returns error result with errorType and statusCode on forbidden', async () => {
       mockHttpClient.delete.mockResolvedValueOnce({
         ok: false,
         error: { type: 'api', status: 403, message: 'Forbidden' },
@@ -64,7 +70,35 @@ describe('useAccountMutation', () => {
         response = await result.current.deleteAccount(1);
       });
 
-      expect(response).toEqual({ success: false, error: 'Forbidden' });
+      // TYPE-006: エラー時にerrorType, statusCodeを保持
+      expect(response).toEqual({
+        success: false,
+        error: 'Forbidden',
+        errorType: 'api',
+        statusCode: 403,
+      });
+    });
+
+    test('returns error result with errorType on network failure', async () => {
+      mockHttpClient.delete.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'network', message: 'Network error' },
+      });
+
+      const { result } = renderHook(() => useAccountMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.deleteAccount(1);
+      });
+
+      // TYPE-006: ネットワークエラー時はstatusCodeなし
+      expect(response).toEqual({
+        success: false,
+        error: 'Network error',
+        errorType: 'network',
+        statusCode: undefined,
+      });
     });
 
     test('calls correct API endpoint with account ID', async () => {

--- a/src/__tests__/mutations/useCommentMutation.test.ts
+++ b/src/__tests__/mutations/useCommentMutation.test.ts
@@ -40,7 +40,7 @@ describe('useCommentMutation', () => {
       });
     });
 
-    test('returns error result on failure', async () => {
+    test('returns error result with errorType and statusCode on failure', async () => {
       mockHttpClient.post.mockResolvedValueOnce({
         ok: false,
         error: { type: 'api', status: 400, message: 'Bad Request' },
@@ -53,7 +53,13 @@ describe('useCommentMutation', () => {
         response = await result.current.createComment('Test', 100);
       });
 
-      expect(response).toEqual({ success: false, error: 'Bad Request' });
+      // TYPE-006: エラー時にerrorType, statusCodeを保持
+      expect(response).toEqual({
+        success: false,
+        error: 'Bad Request',
+        errorType: 'api',
+        statusCode: 400,
+      });
     });
   });
 
@@ -79,7 +85,7 @@ describe('useCommentMutation', () => {
       });
     });
 
-    test('returns error result on failure', async () => {
+    test('returns error result with errorType and statusCode on failure', async () => {
       mockHttpClient.put.mockResolvedValueOnce({
         ok: false,
         error: { type: 'api', status: 404, message: 'Not Found' },
@@ -92,7 +98,13 @@ describe('useCommentMutation', () => {
         response = await result.current.updateComment('Updated', 999);
       });
 
-      expect(response).toEqual({ success: false, error: 'Not Found' });
+      // TYPE-006: エラー時にerrorType, statusCodeを保持
+      expect(response).toEqual({
+        success: false,
+        error: 'Not Found',
+        errorType: 'api',
+        statusCode: 404,
+      });
     });
   });
 
@@ -114,7 +126,7 @@ describe('useCommentMutation', () => {
       expect(mockHttpClient.delete).toHaveBeenCalledWith('/api/comment?commentId=1');
     });
 
-    test('returns error result on failure', async () => {
+    test('returns error result with errorType and statusCode on failure', async () => {
       mockHttpClient.delete.mockResolvedValueOnce({
         ok: false,
         error: { type: 'api', status: 403, message: 'Forbidden' },
@@ -127,7 +139,35 @@ describe('useCommentMutation', () => {
         response = await result.current.deleteComment(1);
       });
 
-      expect(response).toEqual({ success: false, error: 'Forbidden' });
+      // TYPE-006: エラー時にerrorType, statusCodeを保持
+      expect(response).toEqual({
+        success: false,
+        error: 'Forbidden',
+        errorType: 'api',
+        statusCode: 403,
+      });
+    });
+
+    test('returns error result with errorType on network failure', async () => {
+      mockHttpClient.delete.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'network', message: 'Network error' },
+      });
+
+      const { result } = renderHook(() => useCommentMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.deleteComment(1);
+      });
+
+      // TYPE-006: ネットワークエラー時はstatusCodeなし
+      expect(response).toEqual({
+        success: false,
+        error: 'Network error',
+        errorType: 'network',
+        statusCode: undefined,
+      });
     });
   });
 

--- a/src/__tests__/mutations/useTaskMutation.test.ts
+++ b/src/__tests__/mutations/useTaskMutation.test.ts
@@ -68,7 +68,7 @@ describe('useTaskMutation', () => {
       );
     });
 
-    test('returns error on API failure', async () => {
+    test('returns error with errorType and statusCode on API failure', async () => {
       mockHttpClient.put.mockResolvedValueOnce({
         ok: false,
         error: { type: 'api', status: 500, message: 'Server error' },
@@ -86,8 +86,13 @@ describe('useTaskMutation', () => {
         response = await result.current.completeTask(1, 'h1');
       });
 
-      expect(response?.success).toBe(false);
-      expect(response?.error).toBe('Server error');
+      // TYPE-006: エラー時にerrorType, statusCodeを保持
+      expect(response).toEqual({
+        success: false,
+        error: 'Server error',
+        errorType: 'api',
+        statusCode: 500,
+      });
     });
 
     test('prevents duplicate requests for same task', async () => {
@@ -121,7 +126,12 @@ describe('useTaskMutation', () => {
         secondResponse = await result.current.completeTask(1, 'h1');
       });
 
-      expect(secondResponse).toEqual({ success: false, error: '処理中です' });
+      // TYPE-006: 連打防止エラーはvalidationタイプ
+      expect(secondResponse).toEqual({
+        success: false,
+        error: '処理中です',
+        errorType: 'validation',
+      });
 
       // Complete first request
       await act(async () => {
@@ -151,7 +161,7 @@ describe('useTaskMutation', () => {
       expect(mockHttpClient.put).toHaveBeenCalledWith('/api/task/h1/ng');
     });
 
-    test('returns error on API failure', async () => {
+    test('returns error with errorType and statusCode on API failure', async () => {
       mockHttpClient.put.mockResolvedValueOnce({
         ok: false,
         error: { type: 'api', status: 403, message: 'Forbidden' },
@@ -169,8 +179,13 @@ describe('useTaskMutation', () => {
         response = await result.current.markAsNG(1, 'h1');
       });
 
-      expect(response?.success).toBe(false);
-      expect(response?.error).toBe('Forbidden');
+      // TYPE-006: エラー時にerrorType, statusCodeを保持
+      expect(response).toEqual({
+        success: false,
+        error: 'Forbidden',
+        errorType: 'api',
+        statusCode: 403,
+      });
     });
 
     test('prevents duplicate requests for same task', async () => {
@@ -201,7 +216,12 @@ describe('useTaskMutation', () => {
         secondResponse = await result.current.markAsNG(2, 'h2');
       });
 
-      expect(secondResponse).toEqual({ success: false, error: '処理中です' });
+      // TYPE-006: 連打防止エラーはvalidationタイプ
+      expect(secondResponse).toEqual({
+        success: false,
+        error: '処理中です',
+        errorType: 'validation',
+      });
 
       // Complete first request
       await act(async () => {
@@ -231,7 +251,7 @@ describe('useTaskMutation', () => {
       expect(mockHttpClient.put).toHaveBeenCalledWith('/api/task/t1/reassign');
     });
 
-    test('returns error on API failure', async () => {
+    test('returns error with errorType and statusCode on API failure', async () => {
       mockHttpClient.put.mockResolvedValueOnce({
         ok: false,
         error: { type: 'api', status: 404, message: 'Task not found' },
@@ -249,8 +269,13 @@ describe('useTaskMutation', () => {
         response = await result.current.reassign(1, 't1');
       });
 
-      expect(response?.success).toBe(false);
-      expect(response?.error).toBe('Task not found');
+      // TYPE-006: エラー時にerrorType, statusCodeを保持
+      expect(response).toEqual({
+        success: false,
+        error: 'Task not found',
+        errorType: 'api',
+        statusCode: 404,
+      });
     });
 
     test('prevents duplicate requests for same task', async () => {
@@ -281,7 +306,12 @@ describe('useTaskMutation', () => {
         secondResponse = await result.current.reassign(1, 't1');
       });
 
-      expect(secondResponse).toEqual({ success: false, error: '処理中です' });
+      // TYPE-006: 連打防止エラーはvalidationタイプ
+      expect(secondResponse).toEqual({
+        success: false,
+        error: '処理中です',
+        errorType: 'validation',
+      });
 
       // Complete first request
       await act(async () => {

--- a/src/__tests__/mutations/useTaskMutation.test.ts
+++ b/src/__tests__/mutations/useTaskMutation.test.ts
@@ -95,6 +95,33 @@ describe('useTaskMutation', () => {
       });
     });
 
+    test('returns error with errorType on network failure', async () => {
+      mockHttpClient.put.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'network', message: 'Network error' },
+      });
+      mockMutate.mockImplementation(async (updater) => {
+        if (typeof updater === 'function') {
+          await updater(mockTasks);
+        }
+      });
+
+      const { result } = renderHook(() => useTaskMutation(mockMutate));
+
+      let response;
+      await act(async () => {
+        response = await result.current.completeTask(1, 'h1');
+      });
+
+      // TYPE-006: ネットワークエラー時はstatusCodeなし
+      expect(response).toEqual({
+        success: false,
+        error: 'Network error',
+        errorType: 'network',
+        statusCode: undefined,
+      });
+    });
+
     test('prevents duplicate requests for same task', async () => {
       let resolveFirst: () => void;
       const firstPromise = new Promise<void>((resolve) => {
@@ -188,6 +215,33 @@ describe('useTaskMutation', () => {
       });
     });
 
+    test('returns error with errorType on network failure', async () => {
+      mockHttpClient.put.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'network', message: 'Network error' },
+      });
+      mockMutate.mockImplementation(async (updater) => {
+        if (typeof updater === 'function') {
+          await updater(mockTasks);
+        }
+      });
+
+      const { result } = renderHook(() => useTaskMutation(mockMutate));
+
+      let response;
+      await act(async () => {
+        response = await result.current.markAsNG(1, 'h1');
+      });
+
+      // TYPE-006: ネットワークエラー時はstatusCodeなし
+      expect(response).toEqual({
+        success: false,
+        error: 'Network error',
+        errorType: 'network',
+        statusCode: undefined,
+      });
+    });
+
     test('prevents duplicate requests for same task', async () => {
       let resolveFirst: () => void;
       const firstPromise = new Promise<void>((resolve) => {
@@ -275,6 +329,33 @@ describe('useTaskMutation', () => {
         error: 'Task not found',
         errorType: 'api',
         statusCode: 404,
+      });
+    });
+
+    test('returns error with errorType on network failure', async () => {
+      mockHttpClient.put.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'network', message: 'Network error' },
+      });
+      mockMutate.mockImplementation(async (updater) => {
+        if (typeof updater === 'function') {
+          await updater(mockTasks);
+        }
+      });
+
+      const { result } = renderHook(() => useTaskMutation(mockMutate));
+
+      let response;
+      await act(async () => {
+        response = await result.current.reassign(1, 't1');
+      });
+
+      // TYPE-006: ネットワークエラー時はstatusCodeなし
+      expect(response).toEqual({
+        success: false,
+        error: 'Network error',
+        errorType: 'network',
+        statusCode: undefined,
       });
     });
 

--- a/src/mutations/useAccountMutation.ts
+++ b/src/mutations/useAccountMutation.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { httpClient } from '@/src/infra/http';
-import { MutationResult } from '@/src/types';
+import { MutationErrorType, MutationResult } from '@/src/types';
 import { logError } from '@/src/util/safe-logger';
 
 /**
@@ -10,6 +10,7 @@ import { logError } from '@/src/util/safe-logger';
 export const useAccountMutation = () => {
   /**
    * アカウントを削除
+   * TYPE-006: エラー時にerrorType, statusCodeを保持
    */
   const deleteAccount = useCallback(
     async (accountId: number): Promise<MutationResult> => {
@@ -17,7 +18,13 @@ export const useAccountMutation = () => {
 
       if (!result.ok) {
         logError('[deleteAccount]', result.error);
-        return { success: false, error: result.error.message };
+        return {
+          success: false,
+          error: result.error.message,
+          errorType: result.error.type as MutationErrorType,
+          statusCode:
+            result.error.type === 'api' ? result.error.status : undefined,
+        };
       }
 
       return { success: true, data: undefined };

--- a/src/mutations/useCommentMutation.ts
+++ b/src/mutations/useCommentMutation.ts
@@ -1,12 +1,18 @@
 import { useCallback } from 'react';
 
 import { httpClient } from '@/src/infra/http';
-import { Comment, CommentApiResponse, MutationResult } from '@/src/types';
+import {
+  Comment,
+  CommentApiResponse,
+  MutationErrorType,
+  MutationResult,
+} from '@/src/types';
 import { logError } from '@/src/util/safe-logger';
 
 /**
  * コメント操作用のmutation hook
  * POST/PUT/DELETE操作を提供
+ * TYPE-006: エラー時にerrorType, statusCodeを保持
  */
 export const useCommentMutation = () => {
   /**
@@ -25,7 +31,13 @@ export const useCommentMutation = () => {
 
       if (!result.ok) {
         logError('[createComment]', result.error);
-        return { success: false, error: result.error.message };
+        return {
+          success: false,
+          error: result.error.message,
+          errorType: result.error.type as MutationErrorType,
+          statusCode:
+            result.error.type === 'api' ? result.error.status : undefined,
+        };
       }
 
       return { success: true, data: result.value };
@@ -45,7 +57,13 @@ export const useCommentMutation = () => {
 
       if (!result.ok) {
         logError('[updateComment]', result.error);
-        return { success: false, error: result.error.message };
+        return {
+          success: false,
+          error: result.error.message,
+          errorType: result.error.type as MutationErrorType,
+          statusCode:
+            result.error.type === 'api' ? result.error.status : undefined,
+        };
       }
 
       return { success: true, data: result.value };
@@ -64,7 +82,13 @@ export const useCommentMutation = () => {
 
       if (!result.ok) {
         logError('[deleteComment]', result.error);
-        return { success: false, error: result.error.message };
+        return {
+          success: false,
+          error: result.error.message,
+          errorType: result.error.type as MutationErrorType,
+          statusCode:
+            result.error.type === 'api' ? result.error.status : undefined,
+        };
       }
 
       return { success: true, data: result.value };

--- a/src/mutations/useTaskMutation.ts
+++ b/src/mutations/useTaskMutation.ts
@@ -1,8 +1,23 @@
 import { useCallback, useRef } from 'react';
 import { KeyedMutator } from 'swr';
 
+import { DomainError, isDomainError } from '@/src/domain/types/error';
 import { httpClient } from '@/src/infra/http';
-import { MutationResult, Task } from '@/src/types';
+import { MutationErrorType, MutationResult, Task } from '@/src/types';
+
+/**
+ * DomainErrorからMutationResultを生成するヘルパー
+ * TYPE-006: エラー情報を保持してMutationResult形式に変換
+ */
+const toMutationError = (
+  error: DomainError,
+  fallbackMessage: string
+): MutationResult => ({
+  success: false,
+  error: error.message || fallbackMessage,
+  errorType: error.type as MutationErrorType,
+  statusCode: error.type === 'api' ? error.status : undefined,
+});
 
 /**
  * タスク更新用Mutation Hook
@@ -11,6 +26,7 @@ import { MutationResult, Task } from '@/src/types';
  * - 楽観的更新（Optimistic Update）
  * - 連打防止（同一タスクへの重複リクエスト防止）
  * - エラー時の自動ロールバック
+ * - TYPE-006: エラー時にerrorType, statusCodeを保持
  */
 export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
   // 処理中のタスクIDを追跡（連打防止）
@@ -23,7 +39,7 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
     async (taskId: number, historyId: string): Promise<MutationResult> => {
       // 連打防止: 既に処理中なら何もしない
       if (pendingTasksRef.current.has(taskId)) {
-        return { success: false, error: '処理中です' };
+        return { success: false, error: '処理中です', errorType: 'validation' };
       }
       pendingTasksRef.current.add(taskId);
 
@@ -34,7 +50,8 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
               `/api/task/${historyId}/complete`,
             );
             if (!result.ok) {
-              throw new Error(result.error.message);
+              // DomainErrorをそのままthrowしてcatchで処理
+              throw result.error;
             }
             return currentData?.filter((t) => t.id !== taskId);
           },
@@ -47,6 +64,9 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
         );
         return { success: true, data: undefined };
       } catch (e) {
+        if (isDomainError(e)) {
+          return toMutationError(e, '完了処理に失敗しました');
+        }
         const message = e instanceof Error ? e.message : '完了処理に失敗しました';
         return { success: false, error: message };
       } finally {
@@ -62,7 +82,7 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
   const markAsNG = useCallback(
     async (taskId: number, historyId: string): Promise<MutationResult> => {
       if (pendingTasksRef.current.has(taskId)) {
-        return { success: false, error: '処理中です' };
+        return { success: false, error: '処理中です', errorType: 'validation' };
       }
       pendingTasksRef.current.add(taskId);
 
@@ -71,7 +91,7 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
           async (currentData) => {
             const result = await httpClient.put(`/api/task/${historyId}/ng`);
             if (!result.ok) {
-              throw new Error(result.error.message);
+              throw result.error;
             }
             return currentData?.filter((t) => t.id !== taskId);
           },
@@ -84,6 +104,9 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
         );
         return { success: true, data: undefined };
       } catch (e) {
+        if (isDomainError(e)) {
+          return toMutationError(e, 'NG処理に失敗しました');
+        }
         const message = e instanceof Error ? e.message : 'NG処理に失敗しました';
         return { success: false, error: message };
       } finally {
@@ -99,7 +122,7 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
   const reassign = useCallback(
     async (taskId: number, taskIdStr: string): Promise<MutationResult> => {
       if (pendingTasksRef.current.has(taskId)) {
-        return { success: false, error: '処理中です' };
+        return { success: false, error: '処理中です', errorType: 'validation' };
       }
       pendingTasksRef.current.add(taskId);
 
@@ -110,7 +133,7 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
               `/api/task/${taskIdStr}/reassign`,
             );
             if (!result.ok) {
-              throw new Error(result.error.message);
+              throw result.error;
             }
             return currentData?.filter((t) => t.id !== taskId);
           },
@@ -123,6 +146,9 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
         );
         return { success: true, data: undefined };
       } catch (e) {
+        if (isDomainError(e)) {
+          return toMutationError(e, '再アサイン処理に失敗しました');
+        }
         const message =
           e instanceof Error ? e.message : '再アサイン処理に失敗しました';
         return { success: false, error: message };

--- a/src/mutations/useTaskMutation.ts
+++ b/src/mutations/useTaskMutation.ts
@@ -4,20 +4,45 @@ import { KeyedMutator } from 'swr';
 import { DomainError, isDomainError } from '@/src/domain/types/error';
 import { httpClient } from '@/src/infra/http';
 import { MutationErrorType, MutationResult, Task } from '@/src/types';
+import { logError } from '@/src/util/safe-logger';
 
 /**
  * DomainErrorからMutationResultを生成するヘルパー
  * TYPE-006: エラー情報を保持してMutationResult形式に変換
  */
 const toMutationError = (
+  context: string,
   error: DomainError,
   fallbackMessage: string
-): MutationResult => ({
-  success: false,
-  error: error.message || fallbackMessage,
-  errorType: error.type as MutationErrorType,
-  statusCode: error.type === 'api' ? error.status : undefined,
-});
+): MutationResult => {
+  logError(context, error);
+  return {
+    success: false,
+    error: error.message || fallbackMessage,
+    errorType: error.type as MutationErrorType,
+    statusCode: error.type === 'api' ? error.status : undefined,
+  };
+};
+
+/**
+ * 非DomainErrorをMutationResultに変換するヘルパー
+ * TypeError: ネットワークエラー（fetch失敗）
+ * その他: 予期しないエラー
+ */
+const toUnexpectedError = (
+  context: string,
+  error: unknown,
+  fallbackMessage: string
+): MutationResult => {
+  logError(context, error);
+  const isNetworkError = error instanceof TypeError;
+  const message = error instanceof Error ? error.message : fallbackMessage;
+  return {
+    success: false,
+    error: message,
+    errorType: isNetworkError ? 'network' : undefined,
+  };
+};
 
 /**
  * タスク更新用Mutation Hook
@@ -65,10 +90,9 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
         return { success: true, data: undefined };
       } catch (e) {
         if (isDomainError(e)) {
-          return toMutationError(e, '完了処理に失敗しました');
+          return toMutationError('[completeTask]', e, '完了処理に失敗しました');
         }
-        const message = e instanceof Error ? e.message : '完了処理に失敗しました';
-        return { success: false, error: message };
+        return toUnexpectedError('[completeTask]', e, '完了処理に失敗しました');
       } finally {
         pendingTasksRef.current.delete(taskId);
       }
@@ -105,10 +129,9 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
         return { success: true, data: undefined };
       } catch (e) {
         if (isDomainError(e)) {
-          return toMutationError(e, 'NG処理に失敗しました');
+          return toMutationError('[markAsNG]', e, 'NG処理に失敗しました');
         }
-        const message = e instanceof Error ? e.message : 'NG処理に失敗しました';
-        return { success: false, error: message };
+        return toUnexpectedError('[markAsNG]', e, 'NG処理に失敗しました');
       } finally {
         pendingTasksRef.current.delete(taskId);
       }
@@ -147,11 +170,9 @@ export const useTaskMutation = (mutate: KeyedMutator<Task[]>) => {
         return { success: true, data: undefined };
       } catch (e) {
         if (isDomainError(e)) {
-          return toMutationError(e, '再アサイン処理に失敗しました');
+          return toMutationError('[reassign]', e, '再アサイン処理に失敗しました');
         }
-        const message =
-          e instanceof Error ? e.message : '再アサイン処理に失敗しました';
-        return { success: false, error: message };
+        return toUnexpectedError('[reassign]', e, '再アサイン処理に失敗しました');
       } finally {
         pendingTasksRef.current.delete(taskId);
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -139,8 +139,15 @@ export type WeekCompleteData = {
 // CODE-003: 3箇所に重複定義されていた型を統合
 
 /**
+ * エラータイプ（DomainErrorのtype属性を反映）
+ * TYPE-006: mutation層でエラー種別を保持するため追加
+ */
+export type MutationErrorType = 'api' | 'network' | 'validation';
+
+/**
  * Mutation操作の結果型（判別共用体）
  * TYPE-001: 不正な状態（success: true かつ error が存在）を型レベルで防止
+ * TYPE-006: エラー時にerrorType, statusCodeを保持し、DomainError情報を維持
  *
  * @template T - 成功時に返却されるデータの型（デフォルト: undefined）
  *
@@ -153,7 +160,20 @@ export type WeekCompleteData = {
  * // データを返す場合
  * const result: MutationResult<User> = { success: true, data: user };
  * const error: MutationResult<User> = { success: false, error: 'エラーメッセージ' };
+ *
+ * @example
+ * // エラー種別を活用
+ * if (!result.success && result.errorType === 'api' && result.statusCode === 401) {
+ *   redirectToLogin();
+ * }
  */
 export type MutationResult<T = undefined> =
   | { success: true; data: T }
-  | { success: false; error: string };
+  | {
+      success: false;
+      error: string;
+      /** エラー種別（api/network/validation） */
+      errorType?: MutationErrorType;
+      /** APIエラー時のHTTPステータスコード */
+      statusCode?: number;
+    };


### PR DESCRIPTION
## Summary
- MutationResult型にerrorType, statusCodeフィールドを追加
- 全mutation hooks（useAccountMutation, useCommentMutation, useTaskMutation）でDomainError情報を保持
- 後方互換性を維持（新フィールドはオプショナル）

## 変更内容
- `MutationErrorType`型を追加（`'api' | 'network' | 'validation'`）
- `MutationResult`にオプショナルフィールド追加:
  - `errorType?: MutationErrorType`
  - `statusCode?: number`
- 全mutation hooksでエラー情報を保持するよう修正
- `useTaskMutation`では`isDomainError`型ガードを活用して、throw/catchパターンでも情報を維持

## 対応ファイル
- `src/types/index.ts` - 型定義追加
- `src/mutations/useAccountMutation.ts` - エラー情報保持
- `src/mutations/useCommentMutation.ts` - エラー情報保持
- `src/mutations/useTaskMutation.ts` - DomainErrorをthrowして型ガードで判定

## Test plan
- [x] `npm run lint` Pass
- [x] `npm test` Pass (665件)
- [x] useAccountMutation: APIエラー時にerrorType='api', statusCode=4xx/5xxを保持
- [x] useAccountMutation: ネットワークエラー時にerrorType='network', statusCode=undefinedを保持
- [x] useCommentMutation: 同上
- [x] useTaskMutation: APIエラー時にerrorType, statusCodeを保持
- [x] useTaskMutation: 連打防止エラーはerrorType='validation'