### PR TITLE
feat: エリア管理機能（CRUD）の実装

### DIFF
--- a/src/__tests__/app/api/area/[id]/route.test.ts
+++ b/src/__tests__/app/api/area/[id]/route.test.ts
@@ -182,5 +182,38 @@ describe('DELETE /api/area/[id]', () => {
       expect(data.errors).toContain('サーバーエラーが発生しました');
       expect(mockLogError).toHaveBeenCalled();
     });
+
+    it('成功レスポンスのJSONパースに失敗した場合は502を返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error('Invalid JSON');
+        },
+      });
+
+      const response = await DELETE(createRequest('1'), createContext('1'));
+      const data = await response.json();
+
+      expect(response.status).toBe(502);
+      expect(data.errors).toContain('サーバーからの応答を解析できませんでした');
+      expect(mockLogError).toHaveBeenCalled();
+    });
+
+    it('エラーレスポンスのテキスト読み取りに失敗した場合もエラーを返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => {
+          throw new Error('Read error');
+        },
+      });
+
+      const response = await DELETE(createRequest('1'), createContext('1'));
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.errors).toBeDefined();
+      expect(mockLogError).toHaveBeenCalled();
+    });
   });
 });

--- a/src/__tests__/app/api/area/[id]/route.test.ts
+++ b/src/__tests__/app/api/area/[id]/route.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Area DELETE API Route Handler テスト
+ *
+ * DELETE /api/area/[id] - エリア削除
+ */
+import { NextRequest } from 'next/server';
+
+// モック設定
+const mockIsAuthenticated = jest.fn();
+const mockIsAdminFromCookie = jest.fn();
+const mockGetAuthHeaders = jest.fn();
+const mockLogError = jest.fn();
+const mockLogWarn = jest.fn();
+const mockLogDebug = jest.fn();
+
+jest.mock('@/src/util/auth-check', () => ({
+  isAuthenticated: () => mockIsAuthenticated(),
+  isAdminFromCookie: () => mockIsAdminFromCookie(),
+}));
+
+jest.mock('@/src/util/auth-headers', () => ({
+  getAuthHeaders: () => mockGetAuthHeaders(),
+}));
+
+jest.mock('@/src/util/safe-logger', () => ({
+  logError: (...args: unknown[]) => mockLogError(...args),
+  logWarn: (...args: unknown[]) => mockLogWarn(...args),
+  logDebug: (...args: unknown[]) => mockLogDebug(...args),
+}));
+
+// fetchモック
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// 環境変数
+process.env.API_HOST = 'http://localhost:3000';
+
+describe('DELETE /api/area/[id]', () => {
+  let DELETE: (
+    request: NextRequest,
+    context: { params: Promise<{ id: string }> },
+  ) => Promise<Response>;
+
+  beforeAll(async () => {
+    const module = await import('@/src/app/api/area/[id]/route');
+    DELETE = module.DELETE;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsAdminFromCookie.mockReturnValue(true);
+    mockGetAuthHeaders.mockReturnValue({
+      ok: true,
+      headers: { Authorization: 'Bearer test-token' },
+    });
+  });
+
+  const createRequest = (id: string) => {
+    return new NextRequest(`http://localhost/api/area/${id}`, {
+      method: 'DELETE',
+    });
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  describe('認証・認可', () => {
+    it('未認証の場合は401を返す', async () => {
+      mockIsAuthenticated.mockReturnValue(false);
+
+      const response = await DELETE(createRequest('1'), createContext('1'));
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.errors).toContain('認証が必要です');
+    });
+
+    it('管理者でない場合は403を返す', async () => {
+      mockIsAdminFromCookie.mockReturnValue(false);
+
+      const response = await DELETE(createRequest('1'), createContext('1'));
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.errors).toContain('この操作には管理者権限が必要です');
+    });
+  });
+
+  describe('バリデーション', () => {
+    it('idが無効な場合は400を返す', async () => {
+      const response = await DELETE(createRequest('abc'), createContext('abc'));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toBeDefined();
+    });
+
+    it('idが負の数の場合は400を返す', async () => {
+      const response = await DELETE(createRequest('-1'), createContext('-1'));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toBeDefined();
+    });
+
+    it('idが0の場合は400を返す', async () => {
+      const response = await DELETE(createRequest('0'), createContext('0'));
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toBeDefined();
+    });
+  });
+
+  describe('成功ケース', () => {
+    it('エリアを削除して成功メッセージを返す', async () => {
+      const mockResponse = { message: 'エリアを削除しました' };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const response = await DELETE(createRequest('1'), createContext('1'));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/areas/1',
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('エラーケース', () => {
+    it('存在しないエリアの場合は404を返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => JSON.stringify({ error: 'エリアが見つかりません' }),
+      });
+
+      const response = await DELETE(createRequest('999'), createContext('999'));
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.errors).toBeDefined();
+    });
+
+    it('使用中のエリアの場合は409を返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        text: async () =>
+          JSON.stringify({ error: 'このエリアは使用中のため削除できません' }),
+      });
+
+      const response = await DELETE(createRequest('1'), createContext('1'));
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.errors).toBeDefined();
+    });
+
+    it('ネットワークエラー時は500を返す', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const response = await DELETE(createRequest('1'), createContext('1'));
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.errors).toContain('サーバーエラーが発生しました');
+      expect(mockLogError).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/app/api/area/route.test.ts
+++ b/src/__tests__/app/api/area/route.test.ts
@@ -211,6 +211,49 @@ describe('POST /api/area', () => {
       expect(data.errors).toContain('サーバーエラーが発生しました');
       expect(mockLogError).toHaveBeenCalled();
     });
+
+    it('成功レスポンスのJSONパースに失敗した場合は502を返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error('Invalid JSON');
+        },
+      });
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'テストエリア' }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(502);
+      expect(data.errors).toContain('サーバーからの応答を解析できませんでした');
+      expect(mockLogError).toHaveBeenCalled();
+    });
+
+    it('エラーレスポンスのテキスト読み取りに失敗した場合もエラーを返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => {
+          throw new Error('Read error');
+        },
+      });
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'テストエリア' }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.errors).toBeDefined();
+      expect(mockLogError).toHaveBeenCalled();
+    });
   });
 });
 
@@ -384,6 +427,49 @@ describe('PUT /api/area', () => {
 
       expect(response.status).toBe(500);
       expect(data.errors).toContain('サーバーエラーが発生しました');
+      expect(mockLogError).toHaveBeenCalled();
+    });
+
+    it('成功レスポンスのJSONパースに失敗した場合は502を返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error('Invalid JSON');
+        },
+      });
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: '更新エリア' }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(502);
+      expect(data.errors).toContain('サーバーからの応答を解析できませんでした');
+      expect(mockLogError).toHaveBeenCalled();
+    });
+
+    it('エラーレスポンスのテキスト読み取りに失敗した場合もエラーを返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => {
+          throw new Error('Read error');
+        },
+      });
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: '更新エリア' }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.errors).toBeDefined();
       expect(mockLogError).toHaveBeenCalled();
     });
   });

--- a/src/__tests__/app/api/area/route.test.ts
+++ b/src/__tests__/app/api/area/route.test.ts
@@ -1,0 +1,390 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Area API Route Handler テスト
+ *
+ * POST /api/area - エリア新規作成
+ * PUT /api/area - エリア更新
+ */
+import { NextRequest } from 'next/server';
+
+// モック設定
+const mockIsAuthenticated = jest.fn();
+const mockIsAdminFromCookie = jest.fn();
+const mockGetAuthHeaders = jest.fn();
+const mockLogError = jest.fn();
+const mockLogWarn = jest.fn();
+
+jest.mock('@/src/util/auth-check', () => ({
+  isAuthenticated: () => mockIsAuthenticated(),
+  isAdminFromCookie: () => mockIsAdminFromCookie(),
+}));
+
+jest.mock('@/src/util/auth-headers', () => ({
+  getAuthHeaders: () => mockGetAuthHeaders(),
+}));
+
+jest.mock('@/src/util/safe-logger', () => ({
+  logError: (...args: unknown[]) => mockLogError(...args),
+  logWarn: (...args: unknown[]) => mockLogWarn(...args),
+  logDebug: jest.fn(),
+}));
+
+// fetchモック
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// 環境変数
+process.env.API_HOST = 'http://localhost:3000';
+
+describe('POST /api/area', () => {
+  let POST: (request: NextRequest) => Promise<Response>;
+
+  beforeAll(async () => {
+    const module = await import('@/src/app/api/area/route');
+    POST = module.POST;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // デフォルト: 認証・認可成功
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsAdminFromCookie.mockReturnValue(true);
+    mockGetAuthHeaders.mockReturnValue({
+      ok: true,
+      headers: { Authorization: 'Bearer test-token' },
+    });
+  });
+
+  describe('認証・認可', () => {
+    it('未認証の場合は401を返す', async () => {
+      mockIsAuthenticated.mockReturnValue(false);
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'テストエリア' }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.errors).toContain('認証が必要です');
+    });
+
+    it('管理者でない場合は403を返す', async () => {
+      mockIsAdminFromCookie.mockReturnValue(false);
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'テストエリア' }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.errors).toContain('この操作には管理者権限が必要です');
+    });
+  });
+
+  describe('バリデーション', () => {
+    it('不正なJSONの場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'POST',
+        body: 'invalid json',
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('リクエストボディのJSON形式が不正です');
+    });
+
+    it('nameが空の場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'POST',
+        body: JSON.stringify({ name: '' }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('エリア名は必須です');
+    });
+
+    it('nameがnullの場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'POST',
+        body: JSON.stringify({ name: null }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('エリア名は必須です');
+    });
+
+    it('nameが32文字を超える場合は400を返す', async () => {
+      const longName = 'あ'.repeat(33);
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'POST',
+        body: JSON.stringify({ name: longName }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('エリア名は32文字以内で入力してください');
+    });
+  });
+
+  describe('成功ケース', () => {
+    it('エリアを作成して返す', async () => {
+      const mockArea = { id: 1, name: 'テストエリア' };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockArea,
+      });
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'テストエリア' }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual(mockArea);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/areas',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer test-token',
+          }),
+          body: JSON.stringify({ area: { name: 'テストエリア' } }),
+        }),
+      );
+    });
+  });
+
+  describe('エラーケース', () => {
+    it('バックエンドエラー時はエラーメッセージを返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        text: async () => JSON.stringify({ error: 'エリア名は既に使用されています' }),
+      });
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'POST',
+        body: JSON.stringify({ name: '既存エリア' }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.errors).toBeDefined();
+    });
+
+    it('ネットワークエラー時は500を返す', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'テストエリア' }),
+      });
+
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.errors).toContain('サーバーエラーが発生しました');
+      expect(mockLogError).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('PUT /api/area', () => {
+  let PUT: (request: NextRequest) => Promise<Response>;
+
+  beforeAll(async () => {
+    const module = await import('@/src/app/api/area/route');
+    PUT = module.PUT;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsAdminFromCookie.mockReturnValue(true);
+    mockGetAuthHeaders.mockReturnValue({
+      ok: true,
+      headers: { Authorization: 'Bearer test-token' },
+    });
+  });
+
+  describe('認証・認可', () => {
+    it('未認証の場合は401を返す', async () => {
+      mockIsAuthenticated.mockReturnValue(false);
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: '更新エリア' }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.errors).toContain('認証が必要です');
+    });
+
+    it('管理者でない場合は403を返す', async () => {
+      mockIsAdminFromCookie.mockReturnValue(false);
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: '更新エリア' }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.errors).toContain('この操作には管理者権限が必要です');
+    });
+  });
+
+  describe('バリデーション', () => {
+    it('idが無効な場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'PUT',
+        body: JSON.stringify({ id: -1, name: '更新エリア' }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('有効なエリアIDが必要です');
+    });
+
+    it('idが数値でない場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 'abc', name: '更新エリア' }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('有効なエリアIDが必要です');
+    });
+
+    it('nameが空の場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: '' }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('エリア名は必須です');
+    });
+
+    it('nameが32文字を超える場合は400を返す', async () => {
+      const longName = 'あ'.repeat(33);
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: longName }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('エリア名は32文字以内で入力してください');
+    });
+  });
+
+  describe('成功ケース', () => {
+    it('エリアを更新して返す', async () => {
+      const mockArea = { id: 1, name: '更新エリア' };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockArea,
+      });
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: '更新エリア' }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual(mockArea);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/areas/1',
+        expect.objectContaining({
+          method: 'PUT',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer test-token',
+          }),
+          body: JSON.stringify({ area: { name: '更新エリア' } }),
+        }),
+      );
+    });
+  });
+
+  describe('エラーケース', () => {
+    it('存在しないエリアの場合は404を返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => JSON.stringify({ error: 'エリアが見つかりません' }),
+      });
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 999, name: '更新エリア' }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.errors).toBeDefined();
+    });
+
+    it('ネットワークエラー時は500を返す', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const request = new NextRequest('http://localhost/api/area', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: '更新エリア' }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.errors).toContain('サーバーエラーが発生しました');
+      expect(mockLogError).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/app/areas/page.test.tsx
+++ b/src/__tests__/app/areas/page.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * Areas ページテスト
+ *
+ * エリア管理ページ（CRUD）
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import AreasPage from '@/src/app/(admin)/areas/page';
+import { Area } from '@/src/types';
+
+// モック設定
+const mockAreas: Area[] = [
+  { id: 1, name: 'エリアA' },
+  { id: 2, name: 'エリアB' },
+  { id: 3, name: 'テストエリア' },
+];
+
+const mockCreateArea = jest.fn();
+const mockUpdateArea = jest.fn();
+const mockDeleteArea = jest.fn();
+
+jest.mock('@/src/infra/http', () => ({
+  httpClient: {
+    get: jest.fn(),
+  },
+}));
+
+jest.mock('@/src/mutations', () => ({
+  useAreaMutation: () => ({
+    createArea: mockCreateArea,
+    updateArea: mockUpdateArea,
+    deleteArea: mockDeleteArea,
+  }),
+}));
+
+jest.mock('@/src/context/ToastContext', () => ({
+  useToast: () => ({
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+    showErrorWithRetry: jest.fn(),
+    showToast: jest.fn(),
+    removeToast: jest.fn(),
+    toasts: [],
+  }),
+}));
+
+// SWRをモック
+const mockMutate = jest.fn();
+jest.mock('swr', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+import useSWR from 'swr';
+import { httpClient } from '@/src/infra/http';
+
+const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+const mockHttpClient = httpClient as jest.Mocked<typeof httpClient>;
+
+describe('AreasPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateArea.mockResolvedValue({ success: true, data: { id: 4, name: '新規エリア' } });
+    mockUpdateArea.mockResolvedValue({ success: true, data: { id: 1, name: '更新エリア' } });
+    mockDeleteArea.mockResolvedValue({ success: true, data: { message: '削除しました' } });
+  });
+
+  describe('ローディング状態', () => {
+    it('ローディング中はスピナーを表示する', () => {
+      mockUseSWR.mockReturnValue({
+        data: undefined,
+        error: undefined,
+        isLoading: true,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+
+      render(<AreasPage />);
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+
+  describe('データ表示', () => {
+    beforeEach(() => {
+      mockUseSWR.mockReturnValue({
+        data: mockAreas,
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+    });
+
+    it('ページタイトルが表示される', () => {
+      render(<AreasPage />);
+      expect(screen.getByText('エリア管理')).toBeInTheDocument();
+    });
+
+    it('エリア数が表示される', () => {
+      render(<AreasPage />);
+      expect(screen.getByText('3件のエリアが登録されています')).toBeInTheDocument();
+    });
+
+    it('すべてのエリアが表示される', () => {
+      render(<AreasPage />);
+      expect(screen.getByText('エリアA')).toBeInTheDocument();
+      expect(screen.getByText('エリアB')).toBeInTheDocument();
+      expect(screen.getByText('テストエリア')).toBeInTheDocument();
+    });
+
+    it('「エリア追加」ボタンが表示される', () => {
+      render(<AreasPage />);
+      expect(screen.getByRole('button', { name: /エリア追加/ })).toBeInTheDocument();
+    });
+  });
+
+  describe('検索機能', () => {
+    beforeEach(() => {
+      mockUseSWR.mockReturnValue({
+        data: mockAreas,
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+    });
+
+    it('検索バーが表示される', () => {
+      render(<AreasPage />);
+      expect(screen.getByPlaceholderText('エリア名で検索...')).toBeInTheDocument();
+    });
+
+    it('検索でエリアがフィルタリングされる', async () => {
+      render(<AreasPage />);
+
+      const searchInput = screen.getByPlaceholderText('エリア名で検索...');
+      fireEvent.change(searchInput, { target: { value: 'テスト' } });
+
+      await waitFor(() => {
+        expect(screen.getByText('テストエリア')).toBeInTheDocument();
+        expect(screen.queryByText('エリアA')).not.toBeInTheDocument();
+        expect(screen.queryByText('エリアB')).not.toBeInTheDocument();
+      });
+    });
+
+    it('検索結果件数が表示される', async () => {
+      render(<AreasPage />);
+
+      const searchInput = screen.getByPlaceholderText('エリア名で検索...');
+      fireEvent.change(searchInput, { target: { value: 'テスト' } });
+
+      await waitFor(() => {
+        expect(screen.getByText('1件の結果')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('空状態', () => {
+    it('エリアがない場合は空メッセージを表示する', () => {
+      mockUseSWR.mockReturnValue({
+        data: [],
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+
+      render(<AreasPage />);
+      expect(screen.getByText('エリアがまだ登録されていません')).toBeInTheDocument();
+    });
+
+    it('検索結果がない場合は検索メッセージを表示する', async () => {
+      mockUseSWR.mockReturnValue({
+        data: mockAreas,
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+
+      render(<AreasPage />);
+
+      const searchInput = screen.getByPlaceholderText('エリア名で検索...');
+      fireEvent.change(searchInput, { target: { value: '存在しないエリア' } });
+
+      await waitFor(() => {
+        expect(screen.getByText('検索条件に一致するエリアが見つかりません')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('ダイアログ操作', () => {
+    beforeEach(() => {
+      mockUseSWR.mockReturnValue({
+        data: mockAreas,
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+    });
+
+    it('「エリア追加」ボタンでダイアログが開く', async () => {
+      render(<AreasPage />);
+
+      const addButton = screen.getByRole('button', { name: /エリア追加/ });
+      fireEvent.click(addButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('エリア追加', { selector: 'h2' })).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/__tests__/app/areas/page.test.tsx
+++ b/src/__tests__/app/areas/page.test.tsx
@@ -20,6 +20,8 @@ const mockAreas: Area[] = [
 const mockCreateArea = jest.fn();
 const mockUpdateArea = jest.fn();
 const mockDeleteArea = jest.fn();
+const mockShowSuccess = jest.fn();
+const mockShowErrorWithRetry = jest.fn();
 
 jest.mock('@/src/infra/http', () => ({
   httpClient: {
@@ -37,9 +39,9 @@ jest.mock('@/src/mutations', () => ({
 
 jest.mock('@/src/context/ToastContext', () => ({
   useToast: () => ({
-    showSuccess: jest.fn(),
+    showSuccess: mockShowSuccess,
     showError: jest.fn(),
-    showErrorWithRetry: jest.fn(),
+    showErrorWithRetry: mockShowErrorWithRetry,
     showToast: jest.fn(),
     removeToast: jest.fn(),
     toasts: [],
@@ -284,6 +286,152 @@ describe('AreasPage', () => {
 
       await waitFor(() => {
         expect(screen.getByText('エリア追加', { selector: 'h2' })).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('CRUD操作', () => {
+    beforeEach(() => {
+      mockUseSWR.mockReturnValue({
+        data: mockAreas,
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+    });
+
+    describe('作成', () => {
+      it('新規エリア作成が成功するとmutateが呼ばれる', async () => {
+        mockCreateArea.mockResolvedValue({ success: true, data: { id: 4, name: '新規エリア' } });
+        render(<AreasPage />);
+
+        // ダイアログを開く
+        const addButton = screen.getByRole('button', { name: /エリア追加/ });
+        fireEvent.click(addButton);
+
+        await waitFor(() => {
+          expect(screen.getByText('エリア追加', { selector: 'h2' })).toBeInTheDocument();
+        });
+
+        // エリア名を入力して保存（ダイアログ内のテキストボックスを取得）
+        const input = screen.getByRole('textbox');
+        fireEvent.change(input, { target: { value: '新規エリア' } });
+
+        const saveButton = screen.getByRole('button', { name: '追加' });
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+          expect(mockCreateArea).toHaveBeenCalledWith('新規エリア');
+          expect(mockShowSuccess).toHaveBeenCalledWith('エリアを作成しました');
+          expect(mockMutate).toHaveBeenCalled();
+        });
+      });
+
+      it('作成失敗時にshowErrorWithRetryが呼ばれる', async () => {
+        mockCreateArea.mockResolvedValue({ success: false, error: 'エリア名は既に使用されています' });
+        render(<AreasPage />);
+
+        const addButton = screen.getByRole('button', { name: /エリア追加/ });
+        fireEvent.click(addButton);
+
+        await waitFor(() => {
+          expect(screen.getByText('エリア追加', { selector: 'h2' })).toBeInTheDocument();
+        });
+
+        const input = screen.getByRole('textbox');
+        fireEvent.change(input, { target: { value: '既存エリア' } });
+
+        const saveButton = screen.getByRole('button', { name: '追加' });
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+          expect(mockCreateArea).toHaveBeenCalledWith('既存エリア');
+          expect(mockShowErrorWithRetry).toHaveBeenCalled();
+          expect(mockMutate).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('更新', () => {
+      it('エリア更新が成功するとmutateが呼ばれる', async () => {
+        mockUpdateArea.mockResolvedValue({ success: true, data: { id: 1, name: '更新エリア' } });
+        render(<AreasPage />);
+
+        // 編集ボタンをクリック
+        const editButtons = screen.getAllByLabelText('編集');
+        fireEvent.click(editButtons[0]);
+
+        await waitFor(() => {
+          expect(screen.getByText('エリア編集', { selector: 'h2' })).toBeInTheDocument();
+        });
+
+        // エリア名を更新して保存（ダイアログ内のテキストボックスを取得）
+        const input = screen.getByRole('textbox');
+        fireEvent.change(input, { target: { value: '更新エリア' } });
+
+        const saveButton = screen.getByRole('button', { name: '更新' });
+        fireEvent.click(saveButton);
+
+        await waitFor(() => {
+          expect(mockUpdateArea).toHaveBeenCalledWith(1, '更新エリア');
+          expect(mockShowSuccess).toHaveBeenCalledWith('エリアを更新しました');
+          expect(mockMutate).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('削除', () => {
+      it('エリア削除が成功するとmutateが呼ばれる', async () => {
+        // confirmをモック
+        const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+        mockDeleteArea.mockResolvedValue({ success: true });
+        render(<AreasPage />);
+
+        // 削除ボタンをクリック
+        const deleteButtons = screen.getAllByRole('button', { name: '削除' });
+        fireEvent.click(deleteButtons[0]);
+
+        await waitFor(() => {
+          expect(confirmSpy).toHaveBeenCalledWith('エリアAを削除しますか？');
+          expect(mockDeleteArea).toHaveBeenCalledWith(1);
+          expect(mockShowSuccess).toHaveBeenCalledWith('エリアを削除しました');
+          expect(mockMutate).toHaveBeenCalled();
+        });
+
+        confirmSpy.mockRestore();
+      });
+
+      it('確認ダイアログでキャンセルすると削除されない', async () => {
+        const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+        render(<AreasPage />);
+
+        const deleteButtons = screen.getAllByRole('button', { name: '削除' });
+        fireEvent.click(deleteButtons[0]);
+
+        await waitFor(() => {
+          expect(confirmSpy).toHaveBeenCalled();
+          expect(mockDeleteArea).not.toHaveBeenCalled();
+        });
+
+        confirmSpy.mockRestore();
+      });
+
+      it('削除失敗時にshowErrorWithRetryが呼ばれる', async () => {
+        const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+        mockDeleteArea.mockResolvedValue({ success: false, error: '削除できませんでした' });
+        render(<AreasPage />);
+
+        const deleteButtons = screen.getAllByRole('button', { name: '削除' });
+        fireEvent.click(deleteButtons[0]);
+
+        await waitFor(() => {
+          expect(mockDeleteArea).toHaveBeenCalledWith(1);
+          expect(mockShowErrorWithRetry).toHaveBeenCalled();
+          expect(mockMutate).not.toHaveBeenCalled();
+        });
+
+        confirmSpy.mockRestore();
       });
     });
   });

--- a/src/__tests__/app/areas/page.test.tsx
+++ b/src/__tests__/app/areas/page.test.tsx
@@ -191,6 +191,80 @@ describe('AreasPage', () => {
     });
   });
 
+  describe('エラー状態', () => {
+    it('エラー時はエラーメッセージを表示する', () => {
+      mockUseSWR.mockReturnValue({
+        data: undefined,
+        error: new Error('ネットワークエラーが発生しました'),
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+
+      render(<AreasPage />);
+      expect(screen.getByText('エリアの読み込みに失敗しました')).toBeInTheDocument();
+      expect(screen.getByText('ネットワークエラーが発生しました')).toBeInTheDocument();
+    });
+
+    it('エラー時は再試行ボタンが表示される', () => {
+      mockUseSWR.mockReturnValue({
+        data: undefined,
+        error: new Error('エラー'),
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+
+      render(<AreasPage />);
+      expect(screen.getByRole('button', { name: '再試行' })).toBeInTheDocument();
+    });
+
+    it('再試行ボタンをクリックするとmutateが呼ばれる', async () => {
+      mockUseSWR.mockReturnValue({
+        data: undefined,
+        error: new Error('エラー'),
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+
+      render(<AreasPage />);
+      const retryButton = screen.getByRole('button', { name: '再試行' });
+      fireEvent.click(retryButton);
+
+      await waitFor(() => {
+        expect(mockMutate).toHaveBeenCalled();
+      });
+    });
+
+    it('エラー時はエリアカードを表示しない', () => {
+      mockUseSWR.mockReturnValue({
+        data: undefined,
+        error: new Error('エラー'),
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+
+      render(<AreasPage />);
+      expect(screen.queryByText('エリアA')).not.toBeInTheDocument();
+      expect(screen.queryByText('エリアがまだ登録されていません')).not.toBeInTheDocument();
+    });
+
+    it('エラーがError以外の場合は不明なエラーメッセージを表示する', () => {
+      mockUseSWR.mockReturnValue({
+        data: undefined,
+        error: 'string error',
+        isLoading: false,
+        isValidating: false,
+        mutate: mockMutate,
+      } as ReturnType<typeof useSWR>);
+
+      render(<AreasPage />);
+      expect(screen.getByText('不明なエラーが発生しました')).toBeInTheDocument();
+    });
+  });
+
   describe('ダイアログ操作', () => {
     beforeEach(() => {
       mockUseSWR.mockReturnValue({

--- a/src/__tests__/components/AreaCard.test.tsx
+++ b/src/__tests__/components/AreaCard.test.tsx
@@ -39,7 +39,7 @@ describe('AreaCard', () => {
 
     it('削除ボタンが表示される', () => {
       render(<AreaCard {...defaultProps} />);
-      expect(screen.getByLabelText('削除')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '削除' })).toBeInTheDocument();
     });
   });
 
@@ -59,7 +59,7 @@ describe('AreaCard', () => {
       const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
       render(<AreaCard {...defaultProps} />);
 
-      const deleteButton = screen.getByLabelText('削除');
+      const deleteButton = screen.getByRole('button', { name: '削除' });
       fireEvent.click(deleteButton);
 
       expect(confirmSpy).toHaveBeenCalledWith('テストエリアを削除しますか？');
@@ -70,7 +70,7 @@ describe('AreaCard', () => {
       const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
       render(<AreaCard {...defaultProps} />);
 
-      const deleteButton = screen.getByLabelText('削除');
+      const deleteButton = screen.getByRole('button', { name: '削除' });
       fireEvent.click(deleteButton);
 
       expect(mockOnDelete).not.toHaveBeenCalled();
@@ -81,7 +81,7 @@ describe('AreaCard', () => {
       const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
       render(<AreaCard {...defaultProps} />);
 
-      const deleteButton = screen.getByLabelText('削除');
+      const deleteButton = screen.getByRole('button', { name: '削除' });
       fireEvent.click(deleteButton);
 
       expect(mockOnDelete).toHaveBeenCalledWith(1);
@@ -108,6 +108,33 @@ describe('AreaCard', () => {
       const shortNameArea: Area = { id: 3, name: 'A' };
       render(<AreaCard {...defaultProps} area={shortNameArea} />);
       expect(screen.getByText('A')).toBeInTheDocument();
+    });
+  });
+
+  describe('削除中状態', () => {
+    it('isDeleting=trueの時、削除ボタンが無効化される', () => {
+      render(<AreaCard {...defaultProps} isDeleting={true} />);
+
+      const deleteButton = screen.getByRole('button', { name: '削除' });
+      expect(deleteButton).toBeDisabled();
+    });
+
+    it('isDeleting=trueの時、削除ボタンクリックでconfirmが呼ばれない', () => {
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+      render(<AreaCard {...defaultProps} isDeleting={true} />);
+
+      const deleteButton = screen.getByRole('button', { name: '削除' });
+      fireEvent.click(deleteButton);
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(mockOnDelete).not.toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    it('isDeleting=trueの時、ローディングインジケーターが表示される', () => {
+      render(<AreaCard {...defaultProps} isDeleting={true} />);
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
     });
   });
 });

--- a/src/__tests__/components/AreaCard.test.tsx
+++ b/src/__tests__/components/AreaCard.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * AreaCard テスト
+ *
+ * エリアカードコンポーネント
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import AreaCard from '@/src/components/AreaCard';
+import { Area } from '@/src/types';
+
+describe('AreaCard', () => {
+  const mockOnEdit = jest.fn();
+  const mockOnDelete = jest.fn();
+
+  const mockArea: Area = { id: 1, name: 'テストエリア' };
+
+  const defaultProps = {
+    area: mockArea,
+    onEdit: mockOnEdit,
+    onDelete: mockOnDelete,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('表示', () => {
+    it('エリア名が表示される', () => {
+      render(<AreaCard {...defaultProps} />);
+      expect(screen.getByText('テストエリア')).toBeInTheDocument();
+    });
+
+    it('編集ボタンが表示される', () => {
+      render(<AreaCard {...defaultProps} />);
+      expect(screen.getByLabelText('編集')).toBeInTheDocument();
+    });
+
+    it('削除ボタンが表示される', () => {
+      render(<AreaCard {...defaultProps} />);
+      expect(screen.getByLabelText('削除')).toBeInTheDocument();
+    });
+  });
+
+  describe('編集操作', () => {
+    it('編集ボタンをクリックするとonEditが呼ばれる', () => {
+      render(<AreaCard {...defaultProps} />);
+
+      const editButton = screen.getByLabelText('編集');
+      fireEvent.click(editButton);
+
+      expect(mockOnEdit).toHaveBeenCalledWith(mockArea);
+    });
+  });
+
+  describe('削除操作', () => {
+    it('削除ボタンをクリックすると確認ダイアログが表示される', () => {
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+      render(<AreaCard {...defaultProps} />);
+
+      const deleteButton = screen.getByLabelText('削除');
+      fireEvent.click(deleteButton);
+
+      expect(confirmSpy).toHaveBeenCalledWith('テストエリアを削除しますか？');
+      confirmSpy.mockRestore();
+    });
+
+    it('確認ダイアログでキャンセルするとonDeleteが呼ばれない', () => {
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+      render(<AreaCard {...defaultProps} />);
+
+      const deleteButton = screen.getByLabelText('削除');
+      fireEvent.click(deleteButton);
+
+      expect(mockOnDelete).not.toHaveBeenCalled();
+      confirmSpy.mockRestore();
+    });
+
+    it('確認ダイアログでOKするとonDeleteが呼ばれる', () => {
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+      render(<AreaCard {...defaultProps} />);
+
+      const deleteButton = screen.getByLabelText('削除');
+      fireEvent.click(deleteButton);
+
+      expect(mockOnDelete).toHaveBeenCalledWith(1);
+      confirmSpy.mockRestore();
+    });
+  });
+
+  describe('スタイル', () => {
+    it('カードがレンダリングされる', () => {
+      render(<AreaCard {...defaultProps} />);
+      // MUI Cardは role="article" ではなく div としてレンダリングされる
+      expect(screen.getByText('テストエリア').closest('.MuiCard-root')).toBeInTheDocument();
+    });
+  });
+
+  describe('様々なエリア名', () => {
+    it('長いエリア名も表示される', () => {
+      const longNameArea: Area = { id: 2, name: 'とても長いエリア名のテスト' };
+      render(<AreaCard {...defaultProps} area={longNameArea} />);
+      expect(screen.getByText('とても長いエリア名のテスト')).toBeInTheDocument();
+    });
+
+    it('短いエリア名も表示される', () => {
+      const shortNameArea: Area = { id: 3, name: 'A' };
+      render(<AreaCard {...defaultProps} area={shortNameArea} />);
+      expect(screen.getByText('A')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/components/AreaDialog.test.tsx
+++ b/src/__tests__/components/AreaDialog.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * AreaDialog テスト
+ *
+ * エリア作成・編集ダイアログ
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import AreaDialog from '@/src/components/AreaDialog';
+import { Area } from '@/src/types';
+
+/**
+ * MUI TextFieldの入力要素を取得するヘルパー
+ */
+const getInput = (): HTMLInputElement => {
+  return document.querySelector('input[type="text"]') as HTMLInputElement;
+};
+
+describe('AreaDialog', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSave = jest.fn();
+
+  const defaultProps = {
+    open: true,
+    onClose: mockOnClose,
+    onSave: mockOnSave,
+    editingArea: null as Area | null,
+    isSubmitting: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOnSave.mockResolvedValue(undefined);
+  });
+
+  describe('新規作成モード', () => {
+    it('「エリア追加」タイトルが表示される', () => {
+      render(<AreaDialog {...defaultProps} />);
+      expect(screen.getByText('エリア追加')).toBeInTheDocument();
+    });
+
+    it('エリア名入力フィールドが空で表示される', () => {
+      render(<AreaDialog {...defaultProps} />);
+      const input = getInput();
+      expect(input).toHaveValue('');
+    });
+
+    it('保存ボタンのテキストが「追加」になる', () => {
+      render(<AreaDialog {...defaultProps} />);
+      expect(screen.getByRole('button', { name: '追加' })).toBeInTheDocument();
+    });
+  });
+
+  describe('編集モード', () => {
+    const editingArea: Area = { id: 1, name: '既存エリア' };
+
+    it('「エリア編集」タイトルが表示される', () => {
+      render(<AreaDialog {...defaultProps} editingArea={editingArea} />);
+      expect(screen.getByText('エリア編集')).toBeInTheDocument();
+    });
+
+    it('エリア名入力フィールドに既存の名前が表示される', () => {
+      render(<AreaDialog {...defaultProps} editingArea={editingArea} />);
+      const input = getInput();
+      expect(input).toHaveValue('既存エリア');
+    });
+
+    it('保存ボタンのテキストが「更新」になる', () => {
+      render(<AreaDialog {...defaultProps} editingArea={editingArea} />);
+      expect(screen.getByRole('button', { name: '更新' })).toBeInTheDocument();
+    });
+  });
+
+  describe('バリデーション', () => {
+    it('空のエリア名でエラーメッセージが表示される', async () => {
+      render(<AreaDialog {...defaultProps} />);
+
+      const addButton = screen.getByRole('button', { name: '追加' });
+      fireEvent.click(addButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('エリア名は必須です')).toBeInTheDocument();
+      });
+      expect(mockOnSave).not.toHaveBeenCalled();
+    });
+
+    it('32文字を超えるエリア名でエラーメッセージが表示される', async () => {
+      render(<AreaDialog {...defaultProps} />);
+
+      const input = getInput();
+      fireEvent.change(input, { target: { value: 'あ'.repeat(33) } });
+
+      const addButton = screen.getByRole('button', { name: '追加' });
+      fireEvent.click(addButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('エリア名は32文字以内で入力してください')).toBeInTheDocument();
+      });
+      expect(mockOnSave).not.toHaveBeenCalled();
+    });
+
+    it('有効なエリア名でonSaveが呼ばれる', async () => {
+      render(<AreaDialog {...defaultProps} />);
+
+      const input = getInput();
+      fireEvent.change(input, { target: { value: 'テストエリア' } });
+
+      const addButton = screen.getByRole('button', { name: '追加' });
+      fireEvent.click(addButton);
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith('テストエリア');
+      });
+    });
+
+    it('空白のみのエリア名でエラーメッセージが表示される', async () => {
+      render(<AreaDialog {...defaultProps} />);
+
+      const input = getInput();
+      fireEvent.change(input, { target: { value: '   ' } });
+
+      const addButton = screen.getByRole('button', { name: '追加' });
+      fireEvent.click(addButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('エリア名は必須です')).toBeInTheDocument();
+      });
+      expect(mockOnSave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('送信中の状態', () => {
+    it('送信中はボタンが無効化される', () => {
+      render(<AreaDialog {...defaultProps} isSubmitting={true} />);
+
+      const addButton = screen.getByRole('button', { name: '追加中...' });
+      expect(addButton).toBeDisabled();
+    });
+
+    it('送信中は入力フィールドが無効化される', () => {
+      render(<AreaDialog {...defaultProps} isSubmitting={true} />);
+
+      const input = getInput();
+      expect(input).toBeDisabled();
+    });
+  });
+
+  describe('キャンセル操作', () => {
+    it('キャンセルボタンでonCloseが呼ばれる', () => {
+      render(<AreaDialog {...defaultProps} />);
+
+      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      fireEvent.click(cancelButton);
+
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    it('送信中はキャンセルボタンも無効化される', () => {
+      render(<AreaDialog {...defaultProps} isSubmitting={true} />);
+
+      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      expect(cancelButton).toBeDisabled();
+    });
+  });
+
+  describe('ダイアログが閉じているとき', () => {
+    it('ダイアログが表示されない', () => {
+      render(<AreaDialog {...defaultProps} open={false} />);
+      expect(screen.queryByText('エリア追加')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('入力値のトリム', () => {
+    it('前後の空白をトリムしてonSaveを呼ぶ', async () => {
+      render(<AreaDialog {...defaultProps} />);
+
+      const input = getInput();
+      fireEvent.change(input, { target: { value: '  テストエリア  ' } });
+
+      const addButton = screen.getByRole('button', { name: '追加' });
+      fireEvent.click(addButton);
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith('テストエリア');
+      });
+    });
+  });
+});

--- a/src/__tests__/components/Drawer.test.tsx
+++ b/src/__tests__/components/Drawer.test.tsx
@@ -225,20 +225,20 @@ describe('Drawer', () => {
   });
 
   describe('リスト構造', () => {
-    test('メインリストにはListItemButtonが4つある', () => {
+    test('メインリストにはListItemButtonが5つある', () => {
       render(<Drawer {...defaultProps} open={true} />);
 
-      // Main menu items: ダッシュボード、タスク一覧、アカウント一覧、アカウント作成
+      // Main menu items: ダッシュボード、タスク一覧、アカウント一覧、アカウント作成、エリア管理
       // Secondary items: 今月、前四半期、年間
       const listItemButtons = document.querySelectorAll('.MuiListItemButton-root');
-      expect(listItemButtons.length).toBe(7);
+      expect(listItemButtons.length).toBe(8);
     });
 
     test('ListItemIconが各メニュー項目に存在する', () => {
       render(<Drawer {...defaultProps} />);
 
       const listItemIcons = document.querySelectorAll('.MuiListItemIcon-root');
-      expect(listItemIcons.length).toBe(7);
+      expect(listItemIcons.length).toBe(8);
     });
   });
 

--- a/src/__tests__/mutations/useAreaMutation.test.ts
+++ b/src/__tests__/mutations/useAreaMutation.test.ts
@@ -1,0 +1,202 @@
+/**
+ * useAreaMutation テスト
+ *
+ * エリアCRUD操作のMutation Hook
+ */
+import { renderHook, act } from '@testing-library/react';
+
+import { httpClient } from '@/src/infra/http';
+
+// httpClientをモック
+jest.mock('@/src/infra/http', () => ({
+  httpClient: {
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock('@/src/util/safe-logger', () => ({
+  logError: jest.fn(),
+}));
+
+const mockHttpClient = httpClient as jest.Mocked<typeof httpClient>;
+
+describe('useAreaMutation', () => {
+  let useAreaMutation: typeof import('@/src/mutations/useAreaMutation').useAreaMutation;
+
+  beforeAll(async () => {
+    const module = await import('@/src/mutations/useAreaMutation');
+    useAreaMutation = module.useAreaMutation;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createArea', () => {
+    it('成功時にエリアデータを返す', async () => {
+      const mockArea = { id: 1, name: 'テストエリア' };
+      mockHttpClient.post.mockResolvedValueOnce({ ok: true, value: mockArea });
+
+      const { result } = renderHook(() => useAreaMutation());
+
+      let mutationResult: Awaited<ReturnType<typeof result.current.createArea>>;
+      await act(async () => {
+        mutationResult = await result.current.createArea('テストエリア');
+      });
+
+      expect(mutationResult!.success).toBe(true);
+      if (mutationResult!.success) {
+        expect(mutationResult!.data).toEqual(mockArea);
+      }
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/area', { name: 'テストエリア' });
+    });
+
+    it('APIエラー時にエラー情報を返す', async () => {
+      const mockError = { type: 'api', status: 422, message: 'エリア名は既に使用されています' };
+      mockHttpClient.post.mockResolvedValueOnce({ ok: false, error: mockError });
+
+      const { result } = renderHook(() => useAreaMutation());
+
+      let mutationResult: Awaited<ReturnType<typeof result.current.createArea>>;
+      await act(async () => {
+        mutationResult = await result.current.createArea('既存エリア');
+      });
+
+      expect(mutationResult!.success).toBe(false);
+      if (!mutationResult!.success) {
+        expect(mutationResult!.error).toBe('エリア名は既に使用されています');
+        expect(mutationResult!.errorType).toBe('api');
+        expect(mutationResult!.statusCode).toBe(422);
+      }
+    });
+
+    it('ネットワークエラー時にエラー情報を返す', async () => {
+      const mockError = { type: 'network', message: 'ネットワークエラー' };
+      mockHttpClient.post.mockResolvedValueOnce({ ok: false, error: mockError });
+
+      const { result } = renderHook(() => useAreaMutation());
+
+      let mutationResult: Awaited<ReturnType<typeof result.current.createArea>>;
+      await act(async () => {
+        mutationResult = await result.current.createArea('テストエリア');
+      });
+
+      expect(mutationResult!.success).toBe(false);
+      if (!mutationResult!.success) {
+        expect(mutationResult!.error).toBe('ネットワークエラー');
+        expect(mutationResult!.errorType).toBe('network');
+        expect(mutationResult!.statusCode).toBeUndefined();
+      }
+    });
+  });
+
+  describe('updateArea', () => {
+    it('成功時に更新されたエリアデータを返す', async () => {
+      const mockArea = { id: 1, name: '更新エリア' };
+      mockHttpClient.put.mockResolvedValueOnce({ ok: true, value: mockArea });
+
+      const { result } = renderHook(() => useAreaMutation());
+
+      let mutationResult: Awaited<ReturnType<typeof result.current.updateArea>>;
+      await act(async () => {
+        mutationResult = await result.current.updateArea(1, '更新エリア');
+      });
+
+      expect(mutationResult!.success).toBe(true);
+      if (mutationResult!.success) {
+        expect(mutationResult!.data).toEqual(mockArea);
+      }
+      expect(mockHttpClient.put).toHaveBeenCalledWith('/api/area', { id: 1, name: '更新エリア' });
+    });
+
+    it('存在しないエリアの場合はエラーを返す', async () => {
+      const mockError = { type: 'api', status: 404, message: 'エリアが見つかりません' };
+      mockHttpClient.put.mockResolvedValueOnce({ ok: false, error: mockError });
+
+      const { result } = renderHook(() => useAreaMutation());
+
+      let mutationResult: Awaited<ReturnType<typeof result.current.updateArea>>;
+      await act(async () => {
+        mutationResult = await result.current.updateArea(999, '更新エリア');
+      });
+
+      expect(mutationResult!.success).toBe(false);
+      if (!mutationResult!.success) {
+        expect(mutationResult!.error).toBe('エリアが見つかりません');
+        expect(mutationResult!.statusCode).toBe(404);
+      }
+    });
+  });
+
+  describe('deleteArea', () => {
+    it('成功時にメッセージを返す', async () => {
+      const mockResponse = { message: 'エリアを削除しました' };
+      mockHttpClient.delete.mockResolvedValueOnce({ ok: true, value: mockResponse });
+
+      const { result } = renderHook(() => useAreaMutation());
+
+      let mutationResult: Awaited<ReturnType<typeof result.current.deleteArea>>;
+      await act(async () => {
+        mutationResult = await result.current.deleteArea(1);
+      });
+
+      expect(mutationResult!.success).toBe(true);
+      if (mutationResult!.success) {
+        expect(mutationResult!.data).toEqual(mockResponse);
+      }
+      expect(mockHttpClient.delete).toHaveBeenCalledWith('/api/area/1');
+    });
+
+    it('使用中のエリアの場合はエラーを返す', async () => {
+      const mockError = { type: 'api', status: 409, message: 'このエリアは使用中のため削除できません' };
+      mockHttpClient.delete.mockResolvedValueOnce({ ok: false, error: mockError });
+
+      const { result } = renderHook(() => useAreaMutation());
+
+      let mutationResult: Awaited<ReturnType<typeof result.current.deleteArea>>;
+      await act(async () => {
+        mutationResult = await result.current.deleteArea(1);
+      });
+
+      expect(mutationResult!.success).toBe(false);
+      if (!mutationResult!.success) {
+        expect(mutationResult!.error).toBe('このエリアは使用中のため削除できません');
+        expect(mutationResult!.statusCode).toBe(409);
+      }
+    });
+
+    it('存在しないエリアの場合はエラーを返す', async () => {
+      const mockError = { type: 'api', status: 404, message: 'エリアが見つかりません' };
+      mockHttpClient.delete.mockResolvedValueOnce({ ok: false, error: mockError });
+
+      const { result } = renderHook(() => useAreaMutation());
+
+      let mutationResult: Awaited<ReturnType<typeof result.current.deleteArea>>;
+      await act(async () => {
+        mutationResult = await result.current.deleteArea(999);
+      });
+
+      expect(mutationResult!.success).toBe(false);
+      if (!mutationResult!.success) {
+        expect(mutationResult!.error).toBe('エリアが見つかりません');
+        expect(mutationResult!.statusCode).toBe(404);
+      }
+    });
+  });
+
+  describe('Hook安定性', () => {
+    it('複数回レンダーしても同じ関数参照を返す', () => {
+      const { result, rerender } = renderHook(() => useAreaMutation());
+
+      const { createArea: create1, updateArea: update1, deleteArea: delete1 } = result.current;
+
+      rerender();
+
+      expect(result.current.createArea).toBe(create1);
+      expect(result.current.updateArea).toBe(update1);
+      expect(result.current.deleteArea).toBe(delete1);
+    });
+  });
+});

--- a/src/app/(admin)/areas/page.tsx
+++ b/src/app/(admin)/areas/page.tsx
@@ -39,7 +39,7 @@ const fetcher = async (): Promise<Area[]> => {
 };
 
 const AreasPage = () => {
-  const { data: areas, error, isLoading, mutate } = useSWR<Area[]>('areas', fetcher);
+  const { data: areas, error, isLoading, mutate } = useSWR<Area[], Error>('areas', fetcher);
   const { createArea, updateArea, deleteArea } = useAreaMutation();
   const { showSuccess, showErrorWithRetry } = useToast();
 
@@ -297,7 +297,7 @@ const AreasPage = () => {
                 area={area}
                 isDeleting={deletingId === area.id}
                 key={area.id}
-                onDelete={handleDelete}
+                onDelete={(id) => void handleDelete(id)}
                 onEdit={handleOpenEdit}
               />
             ))}

--- a/src/app/(admin)/areas/page.tsx
+++ b/src/app/(admin)/areas/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import AddIcon from '@mui/icons-material/Add';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import PlaceIcon from '@mui/icons-material/Place';
 import SearchIcon from '@mui/icons-material/Search';
 import {
@@ -23,6 +24,7 @@ import { useToast } from '@/src/context/ToastContext';
 import { httpClient } from '@/src/infra/http';
 import { useAreaMutation } from '@/src/mutations';
 import { Area } from '@/src/types';
+import { logError } from '@/src/util/safe-logger';
 
 /**
  * エリアデータのフェッチャー
@@ -30,13 +32,14 @@ import { Area } from '@/src/types';
 const fetcher = async (): Promise<Area[]> => {
   const result = await httpClient.get<Area[]>('/api/areas');
   if (!result.ok) {
+    logError('[AreasPage:fetcher]', result.error);
     throw new Error(result.error.message);
   }
   return result.value;
 };
 
 const AreasPage = () => {
-  const { data: areas, isLoading, mutate } = useSWR<Area[]>('areas', fetcher);
+  const { data: areas, error, isLoading, mutate } = useSWR<Area[]>('areas', fetcher);
   const { createArea, updateArea, deleteArea } = useAreaMutation();
   const { showSuccess, showErrorWithRetry } = useToast();
 
@@ -247,8 +250,36 @@ const AreasPage = () => {
           </Box>
         )}
 
+        {/* エラー状態 */}
+        {error && !isLoading && (
+          <Paper
+            elevation={0}
+            sx={{
+              p: 6,
+              textAlign: 'center',
+              borderRadius: 3,
+              bgcolor: 'white',
+            }}
+          >
+            <ErrorOutlineIcon sx={{ fontSize: 64, color: 'error.main', mb: 2 }} />
+            <Typography color="text.secondary" variant="h6">
+              エリアの読み込みに失敗しました
+            </Typography>
+            <Typography color="text.secondary" sx={{ mt: 1 }} variant="body2">
+              {error instanceof Error ? error.message : '不明なエラーが発生しました'}
+            </Typography>
+            <Button
+              onClick={() => void mutate()}
+              sx={{ mt: 2 }}
+              variant="contained"
+            >
+              再試行
+            </Button>
+          </Paper>
+        )}
+
         {/* エリアカードグリッド */}
-        {!isLoading && filteredAreas.length > 0 && (
+        {!isLoading && !error && filteredAreas.length > 0 && (
           <Box
             sx={{
               display: 'grid',
@@ -274,7 +305,7 @@ const AreasPage = () => {
         )}
 
         {/* 空状態 */}
-        {!isLoading && filteredAreas.length === 0 && (
+        {!isLoading && !error && filteredAreas.length === 0 && (
           <Paper
             elevation={0}
             sx={{

--- a/src/app/(admin)/areas/page.tsx
+++ b/src/app/(admin)/areas/page.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import AddIcon from '@mui/icons-material/Add';
+import PlaceIcon from '@mui/icons-material/Place';
+import SearchIcon from '@mui/icons-material/Search';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  InputAdornment,
+  Paper,
+  TextField,
+  Toolbar,
+  Typography,
+} from '@mui/material';
+import { useCallback, useMemo, useState } from 'react';
+import useSWR from 'swr';
+
+import AreaCard from '@/src/components/AreaCard';
+import AreaDialog from '@/src/components/AreaDialog';
+import { useToast } from '@/src/context/ToastContext';
+import { httpClient } from '@/src/infra/http';
+import { useAreaMutation } from '@/src/mutations';
+import { Area } from '@/src/types';
+
+/**
+ * エリアデータのフェッチャー
+ */
+const fetcher = async (): Promise<Area[]> => {
+  const result = await httpClient.get<Area[]>('/api/areas');
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+  return result.value;
+};
+
+const AreasPage = () => {
+  const { data: areas, isLoading, mutate } = useSWR<Area[]>('areas', fetcher);
+  const { createArea, updateArea, deleteArea } = useAreaMutation();
+  const { showSuccess, showErrorWithRetry } = useToast();
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingArea, setEditingArea] = useState<Area | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 検索フィルタリング
+  const filteredAreas = useMemo(() => {
+    if (!areas) return [];
+    if (!searchQuery.trim()) return areas;
+    const query = searchQuery.toLowerCase();
+    return areas.filter((area) => area.name.toLowerCase().includes(query));
+  }, [areas, searchQuery]);
+
+  // ダイアログを開く（新規作成）
+  const handleOpenCreate = useCallback(() => {
+    setEditingArea(null);
+    setDialogOpen(true);
+  }, []);
+
+  // ダイアログを開く（編集）
+  const handleOpenEdit = useCallback((area: Area) => {
+    setEditingArea(area);
+    setDialogOpen(true);
+  }, []);
+
+  // ダイアログを閉じる
+  const handleCloseDialog = useCallback(() => {
+    setDialogOpen(false);
+    setEditingArea(null);
+  }, []);
+
+  // 保存処理（作成または更新）
+  const handleSave = useCallback(
+    async (name: string) => {
+      setIsSubmitting(true);
+      try {
+        if (editingArea) {
+          // 更新
+          const result = await updateArea(editingArea.id, name);
+          if (result.success) {
+            showSuccess('エリアを更新しました');
+            handleCloseDialog();
+            void mutate();
+          } else {
+            showErrorWithRetry(result.error, () => void handleSave(name));
+          }
+        } else {
+          // 作成
+          const result = await createArea(name);
+          if (result.success) {
+            showSuccess('エリアを作成しました');
+            handleCloseDialog();
+            void mutate();
+          } else {
+            showErrorWithRetry(result.error, () => void handleSave(name));
+          }
+        }
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [editingArea, createArea, updateArea, showSuccess, showErrorWithRetry, handleCloseDialog, mutate],
+  );
+
+  // 削除処理
+  const handleDelete = useCallback(
+    async (id: number) => {
+      const result = await deleteArea(id);
+      if (result.success) {
+        showSuccess('エリアを削除しました');
+        void mutate();
+      } else {
+        showErrorWithRetry(result.error, () => void handleDelete(id));
+      }
+    },
+    [deleteArea, showSuccess, showErrorWithRetry, mutate],
+  );
+
+  const areaCount = areas?.length ?? 0;
+
+  return (
+    <Box
+      sx={{
+        flexGrow: 1,
+        minHeight: '100vh',
+        bgcolor: '#f5f7fa',
+      }}
+    >
+      <Toolbar />
+      <Container maxWidth="xl" sx={{ py: 4 }}>
+        {/* ページヘッダー */}
+        <Paper
+          elevation={0}
+          sx={{
+            p: 3,
+            mb: 4,
+            borderRadius: 3,
+            bgcolor: '#667eea',
+            color: 'white',
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: { xs: 'column', md: 'row' },
+              alignItems: { xs: 'flex-start', md: 'center' },
+              justifyContent: 'space-between',
+              gap: 2,
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <Box
+                sx={{
+                  bgcolor: 'rgba(255,255,255,0.2)',
+                  borderRadius: 2,
+                  p: 1.5,
+                  display: 'flex',
+                }}
+              >
+                <PlaceIcon sx={{ fontSize: 32 }} />
+              </Box>
+              <Box>
+                <Typography
+                  sx={{ fontWeight: 700, fontSize: { xs: '1.5rem', md: '2rem' } }}
+                >
+                  エリア管理
+                </Typography>
+                <Typography sx={{ opacity: 0.9, fontSize: '0.875rem' }}>
+                  {isLoading
+                    ? '読み込み中...'
+                    : `${areaCount}件のエリアが登録されています`}
+                </Typography>
+              </Box>
+            </Box>
+            <Button
+              onClick={handleOpenCreate}
+              size="large"
+              startIcon={<AddIcon />}
+              sx={{
+                bgcolor: 'white',
+                color: '#667eea',
+                fontWeight: 600,
+                px: 3,
+                py: 1.5,
+                borderRadius: 2,
+                textTransform: 'none',
+                '&:hover': {
+                  bgcolor: 'rgba(255,255,255,0.9)',
+                },
+              }}
+              variant="contained"
+            >
+              エリア追加
+            </Button>
+          </Box>
+        </Paper>
+
+        {/* 検索バー */}
+        <Box sx={{ mb: 3 }}>
+          <TextField
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon sx={{ color: 'text.secondary' }} />
+                </InputAdornment>
+              ),
+            }}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="エリア名で検索..."
+            size="small"
+            sx={{
+              width: { xs: '100%', sm: 320 },
+              '& .MuiOutlinedInput-root': {
+                bgcolor: 'white',
+                borderRadius: 2,
+              },
+            }}
+            value={searchQuery}
+          />
+          {searchQuery && (
+            <Typography color="text.secondary" sx={{ mt: 1 }} variant="body2">
+              {filteredAreas.length}件の結果
+            </Typography>
+          )}
+        </Box>
+
+        {/* ローディング状態 */}
+        {isLoading && (
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              py: 8,
+            }}
+          >
+            <CircularProgress size={48} />
+          </Box>
+        )}
+
+        {/* エリアカードグリッド */}
+        {!isLoading && filteredAreas.length > 0 && (
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: {
+                xs: '1fr',
+                sm: 'repeat(2, 1fr)',
+                md: 'repeat(3, 1fr)',
+                lg: 'repeat(4, 1fr)',
+              },
+              gap: 2,
+            }}
+          >
+            {filteredAreas.map((area) => (
+              <AreaCard
+                area={area}
+                key={area.id}
+                onDelete={handleDelete}
+                onEdit={handleOpenEdit}
+              />
+            ))}
+          </Box>
+        )}
+
+        {/* 空状態 */}
+        {!isLoading && filteredAreas.length === 0 && (
+          <Paper
+            elevation={0}
+            sx={{
+              p: 6,
+              textAlign: 'center',
+              borderRadius: 3,
+              bgcolor: 'white',
+            }}
+          >
+            <PlaceIcon sx={{ fontSize: 64, color: 'text.disabled', mb: 2 }} />
+            <Typography color="text.secondary" variant="h6">
+              {searchQuery
+                ? '検索条件に一致するエリアが見つかりません'
+                : 'エリアがまだ登録されていません'}
+            </Typography>
+            {!searchQuery && (
+              <Button
+                onClick={handleOpenCreate}
+                startIcon={<AddIcon />}
+                sx={{ mt: 2 }}
+                variant="contained"
+              >
+                最初のエリアを追加
+              </Button>
+            )}
+          </Paper>
+        )}
+      </Container>
+
+      {/* 作成・編集ダイアログ */}
+      <AreaDialog
+        editingArea={editingArea}
+        isSubmitting={isSubmitting}
+        onClose={handleCloseDialog}
+        onSave={handleSave}
+        open={dialogOpen}
+      />
+    </Box>
+  );
+};
+
+export default AreasPage;

--- a/src/app/(admin)/areas/page.tsx
+++ b/src/app/(admin)/areas/page.tsx
@@ -44,6 +44,7 @@ const AreasPage = () => {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingArea, setEditingArea] = useState<Area | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deletingId, setDeletingId] = useState<number | null>(null);
 
   // 検索フィルタリング
   const filteredAreas = useMemo(() => {
@@ -107,15 +108,21 @@ const AreasPage = () => {
   // 削除処理
   const handleDelete = useCallback(
     async (id: number) => {
-      const result = await deleteArea(id);
-      if (result.success) {
-        showSuccess('エリアを削除しました');
-        void mutate();
-      } else {
-        showErrorWithRetry(result.error, () => void handleDelete(id));
+      if (deletingId !== null) return;
+      setDeletingId(id);
+      try {
+        const result = await deleteArea(id);
+        if (result.success) {
+          showSuccess('エリアを削除しました');
+          void mutate();
+        } else {
+          showErrorWithRetry(result.error, () => void handleDelete(id));
+        }
+      } finally {
+        setDeletingId(null);
       }
     },
-    [deleteArea, showSuccess, showErrorWithRetry, mutate],
+    [deleteArea, showSuccess, showErrorWithRetry, mutate, deletingId],
   );
 
   const areaCount = areas?.length ?? 0;
@@ -257,6 +264,7 @@ const AreasPage = () => {
             {filteredAreas.map((area) => (
               <AreaCard
                 area={area}
+                isDeleting={deletingId === area.id}
                 key={area.id}
                 onDelete={handleDelete}
                 onEdit={handleOpenEdit}

--- a/src/app/api/area/[id]/route.ts
+++ b/src/app/api/area/[id]/route.ts
@@ -1,5 +1,5 @@
 /**
- * Area DELETE API Route Handler
+ * エリア削除API Route Handler
  *
  * DELETE /api/area/[id] - エリア削除
  */

--- a/src/app/api/area/[id]/route.ts
+++ b/src/app/api/area/[id]/route.ts
@@ -41,8 +41,16 @@ export const DELETE = async (_request: NextRequest, context: Context) => {
     });
 
     if (res.ok) {
-      const data: unknown = await res.json();
-      return NextResponse.json(data);
+      try {
+        const data: unknown = await res.json();
+        return NextResponse.json(data);
+      } catch (jsonError) {
+        logError('[DELETE] /api/area/[id]: Success response JSON parse failed', jsonError);
+        return NextResponse.json(
+          { errors: ['サーバーからの応答を解析できませんでした'] },
+          { status: 502 },
+        );
+      }
     } else {
       const errorText = await res.text().catch((err) => {
         logError('[DELETE] /api/area/[id]: res.text() failed', err);

--- a/src/app/api/area/[id]/route.ts
+++ b/src/app/api/area/[id]/route.ts
@@ -1,0 +1,57 @@
+/**
+ * Area DELETE API Route Handler
+ *
+ * DELETE /api/area/[id] - エリア削除
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
+import { requireAdmin, requireAuth, requireValidId } from '@/src/util/route-helpers';
+import { logError } from '@/src/util/safe-logger';
+
+type Context = {
+  params: Promise<{ id: string }>;
+};
+
+/**
+ * DELETE /api/area/[id] - エリア削除
+ */
+export const DELETE = async (_request: NextRequest, context: Context) => {
+  // 認証チェック
+  const auth = requireAuth();
+  if (!auth.ok) return auth.response;
+
+  // 管理者権限チェック
+  const adminResult = requireAdmin();
+  if (!adminResult.ok) return adminResult.response;
+
+  // IDバリデーション
+  const { id: idParam } = await context.params;
+  const idResult = requireValidId(idParam);
+  if (!idResult.ok) return idResult.response;
+  const id = idResult.id;
+
+  try {
+    const res = await fetch(`${process.env.API_HOST}/areas/${id}`, {
+      method: 'DELETE',
+      cache: 'no-store',
+      headers: {
+        ...auth.headers,
+      },
+    });
+
+    if (res.ok) {
+      const data: unknown = await res.json();
+      return NextResponse.json(data);
+    } else {
+      const errorText = await res.text().catch((err) => {
+        logError('[DELETE] /api/area/[id]: res.text() failed', err);
+        return 'レスポンスボディの読み取りに失敗しました';
+      });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
+    }
+  } catch (err) {
+    logError('[DELETE] /api/area/[id]', err);
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
+  }
+};

--- a/src/app/api/area/route.ts
+++ b/src/app/api/area/route.ts
@@ -1,5 +1,5 @@
 /**
- * Area API Route Handler
+ * エリアAPI Route Handler
  *
  * POST /api/area - エリア新規作成
  * PUT /api/area - エリア更新

--- a/src/app/api/area/route.ts
+++ b/src/app/api/area/route.ts
@@ -29,7 +29,7 @@ const validateAreaName = (name: unknown): { valid: true } | { valid: false; erro
   if (!name || typeof name !== 'string' || name.trim() === '') {
     return { valid: false, error: 'エリア名は必須です' };
   }
-  if (name.length > MAX_NAME_LENGTH) {
+  if (name.trim().length > MAX_NAME_LENGTH) {
     return { valid: false, error: 'エリア名は32文字以内で入力してください' };
   }
   return { valid: true };
@@ -51,7 +51,8 @@ export const POST = async (request: NextRequest) => {
   let body: CreateBody;
   try {
     body = (await request.json()) as CreateBody;
-  } catch {
+  } catch (parseError) {
+    logError('[POST] /api/area: JSON parse failed', parseError);
     return NextResponse.json(
       { errors: ['リクエストボディのJSON形式が不正です'] },
       { status: 400 },
@@ -78,8 +79,16 @@ export const POST = async (request: NextRequest) => {
     });
 
     if (res.ok) {
-      const data: unknown = await res.json();
-      return NextResponse.json(data);
+      try {
+        const data: unknown = await res.json();
+        return NextResponse.json(data);
+      } catch (jsonError) {
+        logError('[POST] /api/area: Success response JSON parse failed', jsonError);
+        return NextResponse.json(
+          { errors: ['サーバーからの応答を解析できませんでした'] },
+          { status: 502 },
+        );
+      }
     } else {
       const errorText = await res.text().catch((err) => {
         logError('[POST] /api/area: res.text() failed', err);
@@ -109,7 +118,8 @@ export const PUT = async (request: NextRequest) => {
   let body: UpdateBody;
   try {
     body = (await request.json()) as UpdateBody;
-  } catch {
+  } catch (parseError) {
+    logError('[PUT] /api/area: JSON parse failed', parseError);
     return NextResponse.json(
       { errors: ['リクエストボディのJSON形式が不正です'] },
       { status: 400 },
@@ -141,8 +151,16 @@ export const PUT = async (request: NextRequest) => {
     });
 
     if (res.ok) {
-      const data: unknown = await res.json();
-      return NextResponse.json(data);
+      try {
+        const data: unknown = await res.json();
+        return NextResponse.json(data);
+      } catch (jsonError) {
+        logError('[PUT] /api/area: Success response JSON parse failed', jsonError);
+        return NextResponse.json(
+          { errors: ['サーバーからの応答を解析できませんでした'] },
+          { status: 502 },
+        );
+      }
     } else {
       const errorText = await res.text().catch((err) => {
         logError('[PUT] /api/area: res.text() failed', err);

--- a/src/app/api/area/route.ts
+++ b/src/app/api/area/route.ts
@@ -1,0 +1,157 @@
+/**
+ * Area API Route Handler
+ *
+ * POST /api/area - エリア新規作成
+ * PUT /api/area - エリア更新
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
+import { requireAdmin, requireAuth } from '@/src/util/route-helpers';
+import { logError } from '@/src/util/safe-logger';
+
+/** エリア名の最大文字数 */
+const MAX_NAME_LENGTH = 32;
+
+type CreateBody = {
+  name: string;
+};
+
+type UpdateBody = {
+  id: number;
+  name: string;
+};
+
+/**
+ * エリア名のバリデーション
+ */
+const validateAreaName = (name: unknown): { valid: true } | { valid: false; error: string } => {
+  if (!name || typeof name !== 'string' || name.trim() === '') {
+    return { valid: false, error: 'エリア名は必須です' };
+  }
+  if (name.length > MAX_NAME_LENGTH) {
+    return { valid: false, error: 'エリア名は32文字以内で入力してください' };
+  }
+  return { valid: true };
+};
+
+/**
+ * POST /api/area - エリア新規作成
+ */
+export const POST = async (request: NextRequest) => {
+  // 認証チェック
+  const auth = requireAuth();
+  if (!auth.ok) return auth.response;
+
+  // 管理者権限チェック
+  const adminResult = requireAdmin();
+  if (!adminResult.ok) return adminResult.response;
+
+  // リクエストボディのパース
+  let body: CreateBody;
+  try {
+    body = (await request.json()) as CreateBody;
+  } catch {
+    return NextResponse.json(
+      { errors: ['リクエストボディのJSON形式が不正です'] },
+      { status: 400 },
+    );
+  }
+
+  // エリア名バリデーション
+  const nameResult = validateAreaName(body.name);
+  if (!nameResult.valid) {
+    return NextResponse.json({ errors: [nameResult.error] }, { status: 400 });
+  }
+
+  try {
+    const res = await fetch(`${process.env.API_HOST}/areas`, {
+      method: 'POST',
+      cache: 'no-store',
+      headers: {
+        'Content-Type': 'application/json',
+        ...auth.headers,
+      },
+      body: JSON.stringify({
+        area: { name: body.name.trim() },
+      }),
+    });
+
+    if (res.ok) {
+      const data: unknown = await res.json();
+      return NextResponse.json(data);
+    } else {
+      const errorText = await res.text().catch((err) => {
+        logError('[POST] /api/area: res.text() failed', err);
+        return 'レスポンスボディの読み取りに失敗しました';
+      });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
+    }
+  } catch (err) {
+    logError('[POST] /api/area', err);
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
+  }
+};
+
+/**
+ * PUT /api/area - エリア更新
+ */
+export const PUT = async (request: NextRequest) => {
+  // 認証チェック
+  const auth = requireAuth();
+  if (!auth.ok) return auth.response;
+
+  // 管理者権限チェック
+  const adminResult = requireAdmin();
+  if (!adminResult.ok) return adminResult.response;
+
+  // リクエストボディのパース
+  let body: UpdateBody;
+  try {
+    body = (await request.json()) as UpdateBody;
+  } catch {
+    return NextResponse.json(
+      { errors: ['リクエストボディのJSON形式が不正です'] },
+      { status: 400 },
+    );
+  }
+
+  // IDバリデーション
+  if (!body.id || !Number.isInteger(body.id) || body.id <= 0) {
+    return NextResponse.json({ errors: ['有効なエリアIDが必要です'] }, { status: 400 });
+  }
+
+  // エリア名バリデーション
+  const nameResult = validateAreaName(body.name);
+  if (!nameResult.valid) {
+    return NextResponse.json({ errors: [nameResult.error] }, { status: 400 });
+  }
+
+  try {
+    const res = await fetch(`${process.env.API_HOST}/areas/${body.id}`, {
+      method: 'PUT',
+      cache: 'no-store',
+      headers: {
+        'Content-Type': 'application/json',
+        ...auth.headers,
+      },
+      body: JSON.stringify({
+        area: { name: body.name.trim() },
+      }),
+    });
+
+    if (res.ok) {
+      const data: unknown = await res.json();
+      return NextResponse.json(data);
+    } else {
+      const errorText = await res.text().catch((err) => {
+        logError('[PUT] /api/area: res.text() failed', err);
+        return 'レスポンスボディの読み取りに失敗しました';
+      });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
+    }
+  } catch (err) {
+    logError('[PUT] /api/area', err);
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
+  }
+};

--- a/src/components/AreaCard.tsx
+++ b/src/components/AreaCard.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditIcon from '@mui/icons-material/Edit';
+import PlaceIcon from '@mui/icons-material/Place';
+import { Avatar, Box, Card, CardContent, IconButton, Tooltip, Typography } from '@mui/material';
+import { memo } from 'react';
+
+import { Area } from '@/src/types';
+
+type Props = {
+  area: Area;
+  onEdit: (area: Area) => void;
+  onDelete: (id: number) => void;
+};
+
+/**
+ * エリアカードコンポーネント
+ * エリア名と編集・削除ボタンを表示
+ */
+const AreaCard = ({ area, onEdit, onDelete }: Props) => {
+  const handleDelete = () => {
+    if (confirm(`${area.name}を削除しますか？`)) {
+      onDelete(area.id);
+    }
+  };
+
+  return (
+    <Card
+      sx={{
+        m: 1,
+        width: '100%',
+        maxWidth: 300,
+        borderRadius: 3,
+        transition: 'all 0.2s ease-in-out',
+        '&:hover': {
+          transform: 'translateY(-4px)',
+          boxShadow: '0 12px 24px rgba(0,0,0,0.1)',
+        },
+      }}
+    >
+      {/* ヘッダー部分 */}
+      <Box
+        sx={{
+          bgcolor: '#667eea',
+          p: 2,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+        }}
+      >
+        <Avatar
+          sx={{
+            width: 48,
+            height: 48,
+            bgcolor: 'rgba(255,255,255,0.2)',
+            border: '2px solid rgba(255,255,255,0.3)',
+          }}
+        >
+          <PlaceIcon sx={{ color: 'white' }} />
+        </Avatar>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography
+            noWrap
+            sx={{
+              color: 'white',
+              fontWeight: 700,
+              fontSize: '1.1rem',
+            }}
+          >
+            {area.name}
+          </Typography>
+        </Box>
+      </Box>
+
+      <CardContent sx={{ p: 2 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+          <Tooltip title="編集">
+            <IconButton
+              aria-label="編集"
+              onClick={() => onEdit(area)}
+              size="small"
+              sx={{
+                color: '#667eea',
+                '&:hover': {
+                  bgcolor: 'rgba(102, 126, 234, 0.1)',
+                },
+              }}
+            >
+              <EditIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="削除">
+            <IconButton
+              aria-label="削除"
+              onClick={handleDelete}
+              size="small"
+              sx={{
+                color: 'error.main',
+                '&:hover': {
+                  bgcolor: 'rgba(211, 47, 47, 0.1)',
+                },
+              }}
+            >
+              <DeleteOutlineIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default memo(AreaCard);

--- a/src/components/AreaCard.tsx
+++ b/src/components/AreaCard.tsx
@@ -3,7 +3,16 @@
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import EditIcon from '@mui/icons-material/Edit';
 import PlaceIcon from '@mui/icons-material/Place';
-import { Avatar, Box, Card, CardContent, IconButton, Tooltip, Typography } from '@mui/material';
+import {
+  Avatar,
+  Box,
+  Card,
+  CardContent,
+  CircularProgress,
+  IconButton,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import { memo } from 'react';
 
 import { Area } from '@/src/types';
@@ -12,14 +21,16 @@ type Props = {
   area: Area;
   onEdit: (area: Area) => void;
   onDelete: (id: number) => void;
+  isDeleting?: boolean;
 };
 
 /**
  * エリアカードコンポーネント
  * エリア名と編集・削除ボタンを表示
  */
-const AreaCard = ({ area, onEdit, onDelete }: Props) => {
+const AreaCard = ({ area, onEdit, onDelete, isDeleting = false }: Props) => {
   const handleDelete = () => {
+    if (isDeleting) return;
     if (confirm(`${area.name}を削除しますか？`)) {
       onDelete(area.id);
     }
@@ -90,20 +101,27 @@ const AreaCard = ({ area, onEdit, onDelete }: Props) => {
               <EditIcon fontSize="small" />
             </IconButton>
           </Tooltip>
-          <Tooltip title="削除">
-            <IconButton
-              aria-label="削除"
-              onClick={handleDelete}
-              size="small"
-              sx={{
-                color: 'error.main',
-                '&:hover': {
-                  bgcolor: 'rgba(211, 47, 47, 0.1)',
-                },
-              }}
-            >
-              <DeleteOutlineIcon fontSize="small" />
-            </IconButton>
+          <Tooltip title={isDeleting ? '削除中...' : '削除'}>
+            <span>
+              <IconButton
+                aria-label="削除"
+                disabled={isDeleting}
+                onClick={handleDelete}
+                size="small"
+                sx={{
+                  color: 'error.main',
+                  '&:hover': {
+                    bgcolor: 'rgba(211, 47, 47, 0.1)',
+                  },
+                }}
+              >
+                {isDeleting ? (
+                  <CircularProgress color="error" size={18} />
+                ) : (
+                  <DeleteOutlineIcon fontSize="small" />
+                )}
+              </IconButton>
+            </span>
           </Tooltip>
         </Box>
       </CardContent>

--- a/src/components/AreaDialog.tsx
+++ b/src/components/AreaDialog.tsx
@@ -92,6 +92,7 @@ const AreaDialog = ({ open, onClose, onSave, editingArea, isSubmitting }: Props)
           error={!!error}
           fullWidth
           helperText={error}
+          inputProps={{ maxLength: MAX_NAME_LENGTH + 1 }}
           label="エリア名"
           margin="dense"
           onChange={(e) => {
@@ -99,7 +100,6 @@ const AreaDialog = ({ open, onClose, onSave, editingArea, isSubmitting }: Props)
             setError(null);
           }}
           required
-          inputProps={{ maxLength: MAX_NAME_LENGTH + 1 }}
           value={name}
           variant="outlined"
         />
@@ -117,7 +117,7 @@ const AreaDialog = ({ open, onClose, onSave, editingArea, isSubmitting }: Props)
         </Button>
         <Button
           disabled={isSubmitting}
-          onClick={handleSubmit}
+          onClick={() => void handleSubmit()}
           sx={{
             borderRadius: 2,
             bgcolor: '#667eea',

--- a/src/components/AreaDialog.tsx
+++ b/src/components/AreaDialog.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  TextField,
+} from '@mui/material';
+import { useState, useEffect } from 'react';
+
+import { Area } from '@/src/types';
+
+/** エリア名の最大文字数 */
+const MAX_NAME_LENGTH = 32;
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSave: (name: string) => Promise<void>;
+  editingArea: Area | null;
+  isSubmitting: boolean;
+};
+
+/**
+ * エリア作成・編集ダイアログ
+ * editingAreaがnullの場合は新規作成モード
+ */
+const AreaDialog = ({ open, onClose, onSave, editingArea, isSubmitting }: Props) => {
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const isEditMode = editingArea !== null;
+
+  // ダイアログが開いたとき、または編集対象が変わったときに初期化
+  useEffect(() => {
+    if (open) {
+      setName(editingArea?.name ?? '');
+      setError(null);
+    }
+  }, [open, editingArea]);
+
+  const validate = (value: string): string | null => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return 'エリア名は必須です';
+    }
+    if (trimmed.length > MAX_NAME_LENGTH) {
+      return 'エリア名は32文字以内で入力してください';
+    }
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const validationError = validate(name);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    await onSave(name.trim());
+  };
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog
+      aria-labelledby="area-dialog-title"
+      fullWidth
+      maxWidth="sm"
+      onClose={handleClose}
+      open={open}
+      slotProps={{
+        paper: {
+          sx: {
+            borderRadius: 3,
+          },
+        },
+      }}
+    >
+      <DialogTitle id="area-dialog-title" sx={{ fontWeight: 700 }}>
+        {isEditMode ? 'エリア編集' : 'エリア追加'}
+      </DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          disabled={isSubmitting}
+          error={!!error}
+          fullWidth
+          helperText={error}
+          label="エリア名"
+          margin="dense"
+          onChange={(e) => {
+            setName(e.target.value);
+            setError(null);
+          }}
+          required
+          inputProps={{ maxLength: MAX_NAME_LENGTH + 1 }}
+          value={name}
+          variant="outlined"
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button
+          disabled={isSubmitting}
+          onClick={handleClose}
+          sx={{
+            borderRadius: 2,
+            color: '#667eea',
+          }}
+        >
+          キャンセル
+        </Button>
+        <Button
+          disabled={isSubmitting}
+          onClick={handleSubmit}
+          sx={{
+            borderRadius: 2,
+            bgcolor: '#667eea',
+            color: 'white',
+            px: 3,
+            '&:hover': {
+              bgcolor: '#5a6fd6',
+            },
+          }}
+          variant="contained"
+        >
+          {isSubmitting
+            ? isEditMode
+              ? '更新中...'
+              : '追加中...'
+            : isEditMode
+              ? '更新'
+              : '追加'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AreaDialog;

--- a/src/components/ListItems.tsx
+++ b/src/components/ListItems.tsx
@@ -3,6 +3,7 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
 import PeopleIcon from '@mui/icons-material/People';
 import PersonAddAlt1Icon from '@mui/icons-material/PersonAddAlt1';
+import PlaceIcon from '@mui/icons-material/Place';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
@@ -82,6 +83,19 @@ export const MainListItems = ({ open }: ListItemsProps) => (
         {open && (
           <ListItemText
             primary="アカウント作成"
+            primaryTypographyProps={{ fontWeight: 500 }}
+          />
+        )}
+      </ListItemButton>
+    </Tooltip>
+    <Tooltip arrow disableHoverListener={open} placement="right" title="エリア管理">
+      <ListItemButton href="/areas" sx={listItemStyle}>
+        <ListItemIcon sx={listItemIconStyle}>
+          <PlaceIcon />
+        </ListItemIcon>
+        {open && (
+          <ListItemText
+            primary="エリア管理"
             primaryTypographyProps={{ fontWeight: 500 }}
           />
         )}

--- a/src/mutations/index.ts
+++ b/src/mutations/index.ts
@@ -1,4 +1,5 @@
 export { useAccountMutation } from './useAccountMutation';
+export { useAreaMutation } from './useAreaMutation';
 export { useCommentMutation } from './useCommentMutation';
 export { useFileUpload } from './useFileUpload';
 export { useTaskMutation } from './useTaskMutation';

--- a/src/mutations/useAreaMutation.ts
+++ b/src/mutations/useAreaMutation.ts
@@ -1,0 +1,87 @@
+import { useCallback } from 'react';
+
+import { httpClient } from '@/src/infra/http';
+import { Area, MutationErrorType, MutationResult } from '@/src/types';
+import { logError } from '@/src/util/safe-logger';
+
+/** 削除レスポンス型 */
+type DeleteResponse = { message: string };
+
+/**
+ * エリア操作用のmutation hook
+ * CRUD操作（作成・更新・削除）を提供
+ * TYPE-006: エラー時にerrorType, statusCodeを保持
+ */
+export const useAreaMutation = () => {
+  /**
+   * 新しいエリアを作成
+   */
+  const createArea = useCallback(
+    async (name: string): Promise<MutationResult<Area>> => {
+      const result = await httpClient.post<Area>('/api/area', { name });
+
+      if (!result.ok) {
+        logError('[createArea]', result.error);
+        return {
+          success: false,
+          error: result.error.message,
+          errorType: result.error.type as MutationErrorType,
+          statusCode: result.error.type === 'api' ? result.error.status : undefined,
+        };
+      }
+
+      return { success: true, data: result.value };
+    },
+    [],
+  );
+
+  /**
+   * 既存のエリアを更新
+   */
+  const updateArea = useCallback(
+    async (id: number, name: string): Promise<MutationResult<Area>> => {
+      const result = await httpClient.put<Area>('/api/area', { id, name });
+
+      if (!result.ok) {
+        logError('[updateArea]', result.error);
+        return {
+          success: false,
+          error: result.error.message,
+          errorType: result.error.type as MutationErrorType,
+          statusCode: result.error.type === 'api' ? result.error.status : undefined,
+        };
+      }
+
+      return { success: true, data: result.value };
+    },
+    [],
+  );
+
+  /**
+   * エリアを削除
+   */
+  const deleteArea = useCallback(
+    async (id: number): Promise<MutationResult<DeleteResponse>> => {
+      const result = await httpClient.delete<DeleteResponse>(`/api/area/${id}`);
+
+      if (!result.ok) {
+        logError('[deleteArea]', result.error);
+        return {
+          success: false,
+          error: result.error.message,
+          errorType: result.error.type as MutationErrorType,
+          statusCode: result.error.type === 'api' ? result.error.status : undefined,
+        };
+      }
+
+      return { success: true, data: result.value };
+    },
+    [],
+  );
+
+  return {
+    createArea,
+    updateArea,
+    deleteArea,
+  };
+};


### PR DESCRIPTION
## Summary
- エリアの追加・編集・削除機能を実装
- 新規管理ページ `/areas` を追加
- ナビゲーションに「エリア管理」メニューを追加

## 変更内容

### API Layer
- `POST /api/area` - エリア作成
- `PUT /api/area` - エリア更新
- `DELETE /api/area/[id]` - エリア削除

### Component Layer
- `AreaDialog` - 作成・編集ダイアログ（バリデーション付き）
- `AreaCard` - エリアカードコンポーネント

### Page Layer
- `/areas` - エリア管理ページ（検索・CRUD操作）

## Test plan
- [x] API Route Handlerテスト（27件）
- [x] useAreaMutation Hookテスト（9件）
- [x] AreaDialogテスト（16件）
- [x] AreaCardテスト（10件）
- [x] エリア管理ページテスト（11件）
- [x] 全テスト実行: 754件 Pass
- [x] ESLint: エラーなし