### PR TITLE
feat: メンバー情報編集機能の実装

### DIFF
--- a/src/__tests__/admin/members.test.tsx
+++ b/src/__tests__/admin/members.test.tsx
@@ -43,10 +43,12 @@ const mockAreas: Area[] = [
 
 // SWRモック用のレスポンス設定
 let membersData: MemberStatus[] | undefined = mockMemberStatus;
-const mockMutate = jest.fn((fn) => {
+let areasLoading = false;
+const mockMutate = jest.fn((fn, options) => {
   if (typeof fn === 'function') {
     membersData = fn(membersData);
   }
+  return Promise.resolve(membersData);
 });
 
 // モック関数
@@ -69,9 +71,9 @@ jest.mock('swr', () => ({
     }
     if (key === 'areas') {
       return {
-        data: mockAreas,
+        data: areasLoading ? undefined : mockAreas,
         error: undefined,
-        isLoading: false,
+        isLoading: areasLoading,
         mutate: jest.fn(),
       };
     }
@@ -181,6 +183,7 @@ describe('Members Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     membersData = [...mockMemberStatus];
+    areasLoading = false;
   });
 
   it('renders the component and fetches member status', async () => {
@@ -209,7 +212,38 @@ describe('Members Component', () => {
     });
   });
 
+  it('削除時にサーバー再検証オプションが渡される', async () => {
+    render(<Members />);
+
+    await waitFor(() => {
+      expect(screen.getByText('2名の撮影者が登録されています')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('delete1'));
+
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.any(Function),
+        { revalidate: true },
+      );
+    });
+  });
+
   describe('編集機能', () => {
+    it('エリア読み込み中はページがローディング状態で編集ボタンが表示されない', async () => {
+      areasLoading = true;
+      render(<Members />);
+
+      // ページがローディング状態であることを確認
+      await waitFor(() => {
+        expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+      });
+
+      // メンバーカードが表示されないため編集ボタンもない
+      expect(screen.queryByLabelText('edit1')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('member-edit-dialog')).not.toBeInTheDocument();
+    });
+
     it('編集ボタンクリックでダイアログが開く', async () => {
       render(<Members />);
 

--- a/src/__tests__/admin/members.test.tsx
+++ b/src/__tests__/admin/members.test.tsx
@@ -86,15 +86,15 @@ jest.mock('swr', () => ({
   }),
 }));
 
-// MemberCardモック - onEdit propを追加
+// MemberCardモック - onEdit, onDelete propsを使用
 jest.mock('@/src/components/MemberCard', () => {
   return function MockMemberCard({
     member,
-    handleDelete,
+    onDelete,
     onEdit,
   }: {
     member: MemberStatus;
-    handleDelete: (id: number) => void;
+    onDelete: (id: number) => void;
     onEdit: (member: MemberStatus) => void;
   }) {
     return (
@@ -102,7 +102,7 @@ jest.mock('@/src/components/MemberCard', () => {
         {member.name}
         <button
           aria-label={`delete${member.id}`}
-          onClick={() => handleDelete(member.id)}
+          onClick={() => onDelete(member.id)}
         >
           Delete
         </button>

--- a/src/__tests__/admin/members.test.tsx
+++ b/src/__tests__/admin/members.test.tsx
@@ -49,6 +49,12 @@ const mockMutate = jest.fn((fn) => {
   }
 });
 
+// モック関数
+const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
+const mockShowErrorWithRetry = jest.fn();
+const mockUpdateAccount = jest.fn();
+
 // SWRモック
 jest.mock('swr', () => ({
   __esModule: true,
@@ -111,16 +117,16 @@ jest.mock('@/src/components/MemberCard', () => {
 
 jest.mock('@/src/mutations', () => ({
   useAccountMutation: () => ({
-    updateAccount: jest.fn(),
+    updateAccount: mockUpdateAccount,
     deleteAccount: jest.fn().mockResolvedValue({ success: true }),
   }),
 }));
 
 jest.mock('@/src/context/ToastContext', () => ({
   useToast: () => ({
-    showSuccess: jest.fn(),
-    showError: jest.fn(),
-    showErrorWithRetry: jest.fn(),
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
+    showErrorWithRetry: mockShowErrorWithRetry,
   }),
 }));
 
@@ -137,6 +143,37 @@ jest.mock('next/link', () => {
     <a href={href}>{children}</a>
   );
 });
+
+// MemberEditDialogモック
+let capturedOnSave: ((name: string, areaIds: number[], capacity: number) => Promise<void>) | null = null;
+jest.mock('@/src/components/MemberEditDialog', () => {
+  return function MockMemberEditDialog({
+    open,
+    onSave,
+  }: {
+    open: boolean;
+    onSave: (name: string, areaIds: number[], capacity: number) => Promise<void>;
+  }) {
+    capturedOnSave = onSave;
+    if (!open) return null;
+    return (
+      <div data-testid="member-edit-dialog">
+        <button
+          data-testid="save-button"
+          onClick={() => void onSave('Test User', [1], 5)}
+        >
+          Save
+        </button>
+      </div>
+    );
+  };
+});
+
+jest.mock('@/src/util/safe-logger', () => ({
+  logError: jest.fn(),
+  logWarn: jest.fn(),
+  logDebug: jest.fn(),
+}));
 
 import Members from '@/src/app/(admin)/members/page';
 
@@ -169,6 +206,93 @@ describe('Members Component', () => {
 
     await waitFor(() => {
       expect(mockMutate).toHaveBeenCalled();
+    });
+  });
+
+  describe('編集機能', () => {
+    it('編集ボタンクリックでダイアログが開く', async () => {
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('2名の撮影者が登録されています')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByLabelText('edit1'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('member-edit-dialog')).toBeInTheDocument();
+      });
+    });
+
+    it('更新成功時に成功トーストが表示される', async () => {
+      mockUpdateAccount.mockResolvedValue({ success: true });
+
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('2名の撮影者が登録されています')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByLabelText('edit1'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('member-edit-dialog')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('save-button'));
+
+      await waitFor(() => {
+        expect(mockShowSuccess).toHaveBeenCalledWith('メンバーを更新しました');
+      });
+    });
+
+    it('更新失敗時にリトライ付きエラートーストが表示される', async () => {
+      mockUpdateAccount.mockResolvedValue({ success: false, error: '更新に失敗しました' });
+
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('2名の撮影者が登録されています')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByLabelText('edit1'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('member-edit-dialog')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('save-button'));
+
+      await waitFor(() => {
+        expect(mockShowErrorWithRetry).toHaveBeenCalledWith(
+          '更新に失敗しました',
+          expect.any(Function),
+        );
+      });
+    });
+
+    it('予期せぬエラー発生時に適切なエラーメッセージが表示される', async () => {
+      mockUpdateAccount.mockRejectedValue(new Error('Unexpected error'));
+
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('2名の撮影者が登録されています')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByLabelText('edit1'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('member-edit-dialog')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTestId('save-button'));
+
+      await waitFor(() => {
+        expect(mockShowError).toHaveBeenCalledWith(
+          '予期せぬエラーが発生しました。ページを再読み込みしてください。',
+        );
+      });
     });
   });
 });

--- a/src/__tests__/admin/members.test.tsx
+++ b/src/__tests__/admin/members.test.tsx
@@ -1,28 +1,15 @@
+/**
+ * Members Component - 基本テスト
+ *
+ * メンバー管理ページの基本的な表示・削除機能テスト
+ */
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import Members from '@/src/app/(admin)/members/page';
-import { getAccountStatus } from '@/src/api/get-account-status';
-import { MemberStatus } from '@/src/types';
 
-// モックの設定
-jest.mock('@/src/api/get-account-status');
-jest.mock('@/src/components/MemberCard', () => {
-  return function MockMemberCard({ member, handleDelete }) {
-    return (
-      <div data-testid={`member-card-${member.id}`}>
-        {member.name}
-        <button
-          aria-label={`delete${member.id}`}
-          onClick={() => handleDelete(member.id)}
-        >
-          Delete
-        </button>
-      </div>
-    );
-  };
-});
+import { Area, MemberStatus } from '@/src/types';
 
+// テストデータ
 const mockMemberStatus: MemberStatus[] = [
   {
     id: 1,
@@ -50,9 +37,113 @@ const mockMemberStatus: MemberStatus[] = [
   },
 ];
 
+const mockAreas: Area[] = [
+  { id: 1, name: 'エリアA' },
+];
+
+// SWRモック用のレスポンス設定
+let membersData: MemberStatus[] | undefined = mockMemberStatus;
+const mockMutate = jest.fn((fn) => {
+  if (typeof fn === 'function') {
+    membersData = fn(membersData);
+  }
+});
+
+// SWRモック
+jest.mock('swr', () => ({
+  __esModule: true,
+  default: jest.fn((key: string) => {
+    if (key === 'members') {
+      return {
+        data: membersData,
+        error: undefined,
+        isLoading: false,
+        mutate: mockMutate,
+      };
+    }
+    if (key === 'areas') {
+      return {
+        data: mockAreas,
+        error: undefined,
+        isLoading: false,
+        mutate: jest.fn(),
+      };
+    }
+    return {
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+      mutate: jest.fn(),
+    };
+  }),
+}));
+
+// MemberCardモック - onEdit propを追加
+jest.mock('@/src/components/MemberCard', () => {
+  return function MockMemberCard({
+    member,
+    handleDelete,
+    onEdit,
+  }: {
+    member: MemberStatus;
+    handleDelete: (id: number) => void;
+    onEdit: (member: MemberStatus) => void;
+  }) {
+    return (
+      <div data-testid={`member-card-${member.id}`}>
+        {member.name}
+        <button
+          aria-label={`delete${member.id}`}
+          onClick={() => handleDelete(member.id)}
+        >
+          Delete
+        </button>
+        <button
+          aria-label={`edit${member.id}`}
+          onClick={() => onEdit(member)}
+        >
+          Edit
+        </button>
+      </div>
+    );
+  };
+});
+
+jest.mock('@/src/mutations', () => ({
+  useAccountMutation: () => ({
+    updateAccount: jest.fn(),
+    deleteAccount: jest.fn().mockResolvedValue({ success: true }),
+  }),
+}));
+
+jest.mock('@/src/context/ToastContext', () => ({
+  useToast: () => ({
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+    showErrorWithRetry: jest.fn(),
+  }),
+}));
+
+jest.mock('@/src/infra/http', () => ({
+  httpClient: {
+    get: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock('next/link', () => {
+  return ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  );
+});
+
+import Members from '@/src/app/(admin)/members/page';
+
 describe('Members Component', () => {
   beforeEach(() => {
-    (getAccountStatus as jest.Mock).mockResolvedValue(mockMemberStatus);
+    jest.clearAllMocks();
+    membersData = [...mockMemberStatus];
   });
 
   it('renders the component and fetches member status', async () => {
@@ -77,10 +168,7 @@ describe('Members Component', () => {
     fireEvent.click(screen.getByLabelText('delete1'));
 
     await waitFor(() => {
-      expect(screen.getByText('1名の撮影者が登録されています')).toBeInTheDocument();
+      expect(mockMutate).toHaveBeenCalled();
     });
-
-    expect(screen.queryByTestId('member-card-1')).not.toBeInTheDocument();
-    expect(screen.getByTestId('member-card-2')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/app/api/account/route.test.ts
+++ b/src/__tests__/app/api/account/route.test.ts
@@ -102,6 +102,32 @@ describe('PUT /api/account', () => {
       expect(data.errors).toContain('リクエストボディのJSON形式が不正です');
     });
 
+    it('ボディがnullの場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify(null),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('リクエストボディはオブジェクト形式で指定してください');
+    });
+
+    it('ボディが配列の場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify([1, 2, 3]),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('リクエストボディはオブジェクト形式で指定してください');
+    });
+
     it('idが無効な場合は400を返す', async () => {
       const request = new NextRequest('http://localhost/api/account', {
         method: 'PUT',

--- a/src/__tests__/app/api/account/route.test.ts
+++ b/src/__tests__/app/api/account/route.test.ts
@@ -204,7 +204,7 @@ describe('PUT /api/account', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.errors).toContain('キャパシティは0以上の整数で指定してください');
+      expect(data.errors).toContain('1日の最大撮影数は0以上1000以下の整数で入力してください');
     });
 
     it('capacityが整数でない場合は400を返す', async () => {
@@ -217,7 +217,20 @@ describe('PUT /api/account', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.errors).toContain('キャパシティは0以上の整数で指定してください');
+      expect(data.errors).toContain('1日の最大撮影数は0以上1000以下の整数で入力してください');
+    });
+
+    it('capacityが上限を超える場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: [], capacity: 1001 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('1日の最大撮影数は0以上1000以下の整数で入力してください');
     });
   });
 

--- a/src/__tests__/app/api/account/route.test.ts
+++ b/src/__tests__/app/api/account/route.test.ts
@@ -1,0 +1,420 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Account API Route Handler テスト
+ *
+ * PUT /api/account - メンバー情報更新
+ */
+import { NextRequest } from 'next/server';
+
+// モック設定
+const mockIsAuthenticated = jest.fn();
+const mockIsAdminFromCookie = jest.fn();
+const mockGetAuthHeaders = jest.fn();
+const mockLogError = jest.fn();
+const mockLogWarn = jest.fn();
+
+jest.mock('@/src/util/auth-check', () => ({
+  isAuthenticated: () => mockIsAuthenticated(),
+  isAdminFromCookie: () => mockIsAdminFromCookie(),
+}));
+
+jest.mock('@/src/util/auth-headers', () => ({
+  getAuthHeaders: () => mockGetAuthHeaders(),
+}));
+
+jest.mock('@/src/util/safe-logger', () => ({
+  logError: (...args: unknown[]) => mockLogError(...args),
+  logWarn: (...args: unknown[]) => mockLogWarn(...args),
+  logDebug: jest.fn(),
+}));
+
+// fetchモック
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// 環境変数
+process.env.API_HOST = 'http://localhost:3000';
+
+describe('PUT /api/account', () => {
+  let PUT: (request: NextRequest) => Promise<Response>;
+
+  beforeAll(async () => {
+    const module = await import('@/src/app/api/account/route');
+    PUT = module.PUT;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // デフォルト: 認証・認可成功
+    mockIsAuthenticated.mockReturnValue(true);
+    mockIsAdminFromCookie.mockReturnValue(true);
+    mockGetAuthHeaders.mockReturnValue({
+      ok: true,
+      headers: { Authorization: 'Bearer test-token' },
+    });
+  });
+
+  describe('認証・認可', () => {
+    it('未認証の場合は401を返す', async () => {
+      mockIsAuthenticated.mockReturnValue(false);
+
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.errors).toContain('認証が必要です');
+    });
+
+    it('管理者でない場合は403を返す', async () => {
+      mockIsAdminFromCookie.mockReturnValue(false);
+
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.errors).toContain('この操作には管理者権限が必要です');
+    });
+  });
+
+  describe('バリデーション', () => {
+    it('不正なJSONの場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: 'invalid json',
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('リクエストボディのJSON形式が不正です');
+    });
+
+    it('idが無効な場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: -1, name: 'テスト', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('有効なアカウントIDが必要です');
+    });
+
+    it('idが数値でない場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 'abc', name: 'テスト', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('有効なアカウントIDが必要です');
+    });
+
+    it('nameが空の場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: '', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('名前は必須です');
+    });
+
+    it('nameがnullの場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: null, area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('名前は必須です');
+    });
+
+    it('nameが32文字を超える場合は400を返す', async () => {
+      const longName = 'あ'.repeat(33);
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: longName, area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('名前は32文字以内で入力してください');
+    });
+
+    it('areaが配列でない場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: 'invalid', capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('エリアは配列で指定してください');
+    });
+
+    it('areaに無効なIDが含まれる場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: [1, -2, 3], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('エリアIDは正の整数で指定してください');
+    });
+
+    it('capacityが負数の場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: [], capacity: -1 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('キャパシティは0以上の整数で指定してください');
+    });
+
+    it('capacityが整数でない場合は400を返す', async () => {
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: [], capacity: 1.5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.errors).toContain('キャパシティは0以上の整数で指定してください');
+    });
+  });
+
+  describe('成功ケース', () => {
+    it('メンバー情報を更新して返す', async () => {
+      const mockAccount = {
+        id: 1,
+        name: '更新メンバー',
+        area: ['エリアA'],
+        capacity: 10,
+      };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockAccount,
+      });
+
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: '更新メンバー', area: [1], capacity: 10 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual(mockAccount);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/accounts/1',
+        expect.objectContaining({
+          method: 'PUT',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer test-token',
+          }),
+          body: JSON.stringify({
+            account: { name: '更新メンバー', area: [1], capacity: 10 },
+          }),
+        }),
+      );
+    });
+
+    it('nameの前後の空白をトリムして更新する', async () => {
+      const mockAccount = { id: 1, name: '更新メンバー', area: [], capacity: 5 };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockAccount,
+      });
+
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: '  更新メンバー  ', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+
+      expect(response.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: JSON.stringify({
+            account: { name: '更新メンバー', area: [], capacity: 5 },
+          }),
+        }),
+      );
+    });
+
+    it('areaが空配列でも更新できる', async () => {
+      const mockAccount = { id: 1, name: 'テスト', area: [], capacity: 5 };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockAccount,
+      });
+
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+
+      expect(response.status).toBe(200);
+    });
+
+    it('capacityが0でも更新できる', async () => {
+      const mockAccount = { id: 1, name: 'テスト', area: [], capacity: 0 };
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockAccount,
+      });
+
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: [], capacity: 0 }),
+      });
+
+      const response = await PUT(request);
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('エラーケース', () => {
+    it('存在しないアカウントの場合は404を返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        text: async () => JSON.stringify({ error: 'アカウントが見つかりません' }),
+      });
+
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 999, name: 'テスト', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.errors).toBeDefined();
+    });
+
+    it('バックエンドエラー時はエラーメッセージを返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        text: async () => JSON.stringify({ error: '名前は既に使用されています' }),
+      });
+
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: '既存名', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(422);
+      expect(data.errors).toBeDefined();
+    });
+
+    it('ネットワークエラー時は500を返す', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.errors).toContain('サーバーエラーが発生しました');
+      expect(mockLogError).toHaveBeenCalled();
+    });
+
+    it('成功レスポンスのJSONパースに失敗した場合は502を返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error('Invalid JSON');
+        },
+      });
+
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(502);
+      expect(data.errors).toContain('サーバーからの応答を解析できませんでした');
+      expect(mockLogError).toHaveBeenCalled();
+    });
+
+    it('エラーレスポンスのテキスト読み取りに失敗した場合もエラーを返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => {
+          throw new Error('Read error');
+        },
+      });
+
+      const request = new NextRequest('http://localhost/api/account', {
+        method: 'PUT',
+        body: JSON.stringify({ id: 1, name: 'テスト', area: [], capacity: 5 }),
+      });
+
+      const response = await PUT(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.errors).toBeDefined();
+      expect(mockLogError).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/app/api/accounts/route.test.ts
+++ b/src/__tests__/app/api/accounts/route.test.ts
@@ -9,11 +9,13 @@
 
 // モック設定
 const mockIsAuthenticated = jest.fn();
+const mockIsAdminFromCookie = jest.fn();
 const mockGetAuthHeaders = jest.fn();
 const mockLogError = jest.fn();
 
 jest.mock('@/src/util/auth-check', () => ({
   isAuthenticated: () => mockIsAuthenticated(),
+  isAdminFromCookie: () => mockIsAdminFromCookie(),
 }));
 
 jest.mock('@/src/util/auth-headers', () => ({
@@ -43,14 +45,16 @@ describe('GET /api/accounts', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // デフォルト: 認証・認可成功
     mockIsAuthenticated.mockReturnValue(true);
+    mockIsAdminFromCookie.mockReturnValue(true);
     mockGetAuthHeaders.mockReturnValue({
       ok: true,
       headers: { Authorization: 'Bearer test-token' },
     });
   });
 
-  describe('認証', () => {
+  describe('認証・認可', () => {
     it('未認証の場合は401を返す', async () => {
       mockIsAuthenticated.mockReturnValue(false);
 
@@ -59,6 +63,16 @@ describe('GET /api/accounts', () => {
 
       expect(response.status).toBe(401);
       expect(data.errors).toContain('認証が必要です');
+    });
+
+    it('管理者でない場合は403を返す', async () => {
+      mockIsAdminFromCookie.mockReturnValue(false);
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.errors).toContain('この操作には管理者権限が必要です');
     });
   });
 

--- a/src/__tests__/app/api/accounts/route.test.ts
+++ b/src/__tests__/app/api/accounts/route.test.ts
@@ -1,0 +1,189 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Accounts API Route Handler テスト
+ *
+ * GET /api/accounts - メンバー一覧取得
+ */
+
+// モック設定
+const mockIsAuthenticated = jest.fn();
+const mockGetAuthHeaders = jest.fn();
+const mockLogError = jest.fn();
+
+jest.mock('@/src/util/auth-check', () => ({
+  isAuthenticated: () => mockIsAuthenticated(),
+}));
+
+jest.mock('@/src/util/auth-headers', () => ({
+  getAuthHeaders: () => mockGetAuthHeaders(),
+}));
+
+jest.mock('@/src/util/safe-logger', () => ({
+  logError: (...args: unknown[]) => mockLogError(...args),
+  logWarn: jest.fn(),
+  logDebug: jest.fn(),
+}));
+
+// fetchモック
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// 環境変数
+process.env.API_HOST = 'http://localhost:3000';
+
+describe('GET /api/accounts', () => {
+  let GET: () => Promise<Response>;
+
+  beforeAll(async () => {
+    const module = await import('@/src/app/api/accounts/route');
+    GET = module.GET;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsAuthenticated.mockReturnValue(true);
+    mockGetAuthHeaders.mockReturnValue({
+      ok: true,
+      headers: { Authorization: 'Bearer test-token' },
+    });
+  });
+
+  describe('認証', () => {
+    it('未認証の場合は401を返す', async () => {
+      mockIsAuthenticated.mockReturnValue(false);
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(data.errors).toContain('認証が必要です');
+    });
+  });
+
+  describe('成功ケース', () => {
+    it('メンバー一覧を返す', async () => {
+      const mockMembers = [
+        {
+          id: 1,
+          name: '山田太郎',
+          capacity: 5,
+          area: ['エリアA'],
+          total: 10,
+          week: 2,
+          ng_rate: 0.1,
+          assign: 3,
+          createdAt: '2024-01-01',
+          updatedAt: '2024-01-02',
+        },
+        {
+          id: 2,
+          name: '佐藤花子',
+          capacity: 3,
+          area: [],
+          total: 5,
+          week: 1,
+          ng_rate: 0,
+          assign: 1,
+          createdAt: '2024-01-01',
+          updatedAt: '2024-01-02',
+        },
+      ];
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockMembers,
+      });
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual(mockMembers);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:3000/accounts',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+    });
+
+    it('空配列を返す場合も正常に動作する', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      });
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual([]);
+    });
+  });
+
+  describe('エラーケース', () => {
+    it('バックエンドエラー時はエラーメッセージを返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => JSON.stringify({ error: 'サーバーエラー' }),
+      });
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.errors).toBeDefined();
+    });
+
+    it('ネットワークエラー時は500を返す', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.errors).toContain('サーバーエラーが発生しました');
+      expect(mockLogError).toHaveBeenCalled();
+    });
+
+    it('JSONパースエラー時は502を返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ 'content-type': 'text/html' }),
+        json: async () => {
+          throw new Error('Invalid JSON');
+        },
+      });
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(502);
+      expect(data.errors).toContain('バックエンドから不正なレスポンスを受信しました');
+      expect(mockLogError).toHaveBeenCalled();
+    });
+
+    it('エラーレスポンスのテキスト読み取り失敗時もエラーを返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => {
+          throw new Error('Read error');
+        },
+      });
+
+      const response = await GET();
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.errors).toBeDefined();
+      expect(mockLogError).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/app/members/page.test.tsx
+++ b/src/__tests__/app/members/page.test.tsx
@@ -13,6 +13,7 @@ import { Area, MemberStatus } from '@/src/types';
 const mockMutate = jest.fn();
 const mockUpdateAccount = jest.fn();
 const mockShowSuccess = jest.fn();
+const mockShowError = jest.fn();
 const mockShowErrorWithRetry = jest.fn();
 
 // テストデータ
@@ -107,7 +108,7 @@ jest.mock('@/src/mutations', () => ({
 jest.mock('@/src/context/ToastContext', () => ({
   useToast: () => ({
     showSuccess: mockShowSuccess,
-    showError: jest.fn(),
+    showError: mockShowError,
     showErrorWithRetry: mockShowErrorWithRetry,
   }),
 }));
@@ -326,6 +327,27 @@ describe('Members Page', () => {
         expect(screen.getByText('山田太郎')).toBeInTheDocument();
         expect(screen.getByText('佐藤花子')).toBeInTheDocument();
       });
+    });
+
+    it('エリア読み込みエラー時に編集ボタンをクリックするとエラートーストが表示される', async () => {
+      areasResponse = {
+        data: undefined,
+        error: new Error('エリアの読み込みに失敗'),
+        isLoading: false,
+        mutate: jest.fn(),
+      };
+
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('山田太郎')).toBeInTheDocument();
+      });
+
+      const editButtons = screen.getAllByLabelText('編集');
+      fireEvent.click(editButtons[0]);
+
+      expect(mockShowError).toHaveBeenCalledWith('エリア情報の読み込みに失敗したため、編集できません');
+      expect(screen.queryByText('メンバー編集')).not.toBeInTheDocument();
     });
   });
 

--- a/src/__tests__/app/members/page.test.tsx
+++ b/src/__tests__/app/members/page.test.tsx
@@ -1,0 +1,348 @@
+/**
+ * Members ページテスト
+ *
+ * メンバー管理ページ（編集機能追加対応）
+ */
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { Area, MemberStatus } from '@/src/types';
+
+// モック設定
+const mockMutate = jest.fn();
+const mockUpdateAccount = jest.fn();
+const mockShowSuccess = jest.fn();
+const mockShowErrorWithRetry = jest.fn();
+
+// テストデータ
+const mockMembers: MemberStatus[] = [
+  {
+    id: 1,
+    name: '山田太郎',
+    capacity: 5,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-02T00:00:00Z',
+    area: ['エリアA', 'エリアB'],
+    total: 50,
+    week: 5,
+    ng_rate: 0.1,
+    assign: 3,
+  },
+  {
+    id: 2,
+    name: '佐藤花子',
+    capacity: 3,
+    createdAt: '2024-01-03T00:00:00Z',
+    updatedAt: '2024-01-04T00:00:00Z',
+    area: ['エリアC'],
+    total: 30,
+    week: 3,
+    ng_rate: 0.05,
+    assign: 2,
+  },
+];
+
+const mockAreas: Area[] = [
+  { id: 1, name: 'エリアA' },
+  { id: 2, name: 'エリアB' },
+  { id: 3, name: 'エリアC' },
+];
+
+// SWRモック用のレスポンス設定
+let membersResponse: {
+  data?: MemberStatus[];
+  error?: Error;
+  isLoading: boolean;
+  mutate: jest.Mock;
+};
+let areasResponse: {
+  data?: Area[];
+  error?: Error;
+  isLoading: boolean;
+  mutate: jest.Mock;
+};
+
+// SWRモック
+jest.mock('swr', () => ({
+  __esModule: true,
+  default: jest.fn((key: string) => {
+    if (key === 'members') {
+      return membersResponse;
+    }
+    if (key === 'areas') {
+      return areasResponse;
+    }
+    return {
+      data: undefined,
+      error: undefined,
+      isLoading: true,
+      mutate: jest.fn(),
+    };
+  }),
+}));
+
+// MUI コンポーネントのモック
+jest.mock('@mui/material', () => {
+  const actualMui = jest.requireActual('@mui/material');
+  return {
+    ...actualMui,
+    CircularProgress: () => <div data-testid="loading-spinner">Loading...</div>,
+  };
+});
+
+jest.mock('next/link', () => {
+  return ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  );
+});
+
+jest.mock('@/src/mutations', () => ({
+  useAccountMutation: () => ({
+    updateAccount: mockUpdateAccount,
+    deleteAccount: jest.fn().mockResolvedValue({ success: true }),
+  }),
+}));
+
+jest.mock('@/src/context/ToastContext', () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: jest.fn(),
+    showErrorWithRetry: mockShowErrorWithRetry,
+  }),
+}));
+
+jest.mock('@/src/infra/http', () => ({
+  httpClient: {
+    get: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+// テスト対象のページをインポート（モック設定後）
+import Members from '@/src/app/(admin)/members/page';
+
+describe('Members Page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateAccount.mockResolvedValue({ success: true, data: mockMembers[0] });
+
+    // デフォルトのレスポンス設定
+    membersResponse = {
+      data: mockMembers,
+      error: undefined,
+      isLoading: false,
+      mutate: mockMutate,
+    };
+    areasResponse = {
+      data: mockAreas,
+      error: undefined,
+      isLoading: false,
+      mutate: jest.fn(),
+    };
+  });
+
+  describe('ローディング状態', () => {
+    it('ローディング中はスピナーが表示される', () => {
+      membersResponse = {
+        data: undefined,
+        error: undefined,
+        isLoading: true,
+        mutate: mockMutate,
+      };
+
+      render(<Members />);
+      expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
+    });
+  });
+
+  describe('メンバー一覧表示', () => {
+    it('メンバーが正しく表示される', async () => {
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('山田太郎')).toBeInTheDocument();
+        expect(screen.getByText('佐藤花子')).toBeInTheDocument();
+      });
+    });
+
+    it('ページタイトルとメンバー数が表示される', async () => {
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('撮影者管理')).toBeInTheDocument();
+        expect(screen.getByText('2名の撮影者が登録されています')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('編集機能', () => {
+    it('編集ボタンをクリックするとダイアログが開く', async () => {
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('山田太郎')).toBeInTheDocument();
+      });
+
+      // 編集ボタンをクリック
+      const editButtons = screen.getAllByLabelText('編集');
+      fireEvent.click(editButtons[0]);
+
+      // ダイアログが開く
+      await waitFor(() => {
+        expect(screen.getByText('メンバー編集')).toBeInTheDocument();
+      });
+    });
+
+    it('ダイアログにメンバー情報が表示される', async () => {
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('山田太郎')).toBeInTheDocument();
+      });
+
+      const editButtons = screen.getAllByLabelText('編集');
+      fireEvent.click(editButtons[0]);
+
+      await waitFor(() => {
+        const nameInput = screen.getByRole('textbox', { name: /名前/ });
+        expect(nameInput).toHaveValue('山田太郎');
+      });
+    });
+
+    it('更新成功時にトーストが表示されダイアログが閉じる', async () => {
+      mockUpdateAccount.mockResolvedValue({ success: true, data: mockMembers[0] });
+
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('山田太郎')).toBeInTheDocument();
+      });
+
+      const editButtons = screen.getAllByLabelText('編集');
+      fireEvent.click(editButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText('メンバー編集')).toBeInTheDocument();
+      });
+
+      // 更新ボタンをクリック
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      await act(async () => {
+        fireEvent.click(updateButton);
+      });
+
+      await waitFor(() => {
+        expect(mockUpdateAccount).toHaveBeenCalledWith(1, '山田太郎', [1, 2], 5);
+        expect(mockShowSuccess).toHaveBeenCalledWith('メンバーを更新しました');
+        expect(mockMutate).toHaveBeenCalled();
+      });
+    });
+
+    it('更新失敗時にエラートーストが表示される', async () => {
+      mockUpdateAccount.mockResolvedValue({
+        success: false,
+        error: '更新に失敗しました',
+      });
+
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('山田太郎')).toBeInTheDocument();
+      });
+
+      const editButtons = screen.getAllByLabelText('編集');
+      fireEvent.click(editButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText('メンバー編集')).toBeInTheDocument();
+      });
+
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      await act(async () => {
+        fireEvent.click(updateButton);
+      });
+
+      await waitFor(() => {
+        expect(mockShowErrorWithRetry).toHaveBeenCalled();
+      });
+    });
+
+    it('キャンセルボタンでダイアログが閉じる', async () => {
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('山田太郎')).toBeInTheDocument();
+      });
+
+      const editButtons = screen.getAllByLabelText('編集');
+      fireEvent.click(editButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText('メンバー編集')).toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+      fireEvent.click(cancelButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText('メンバー編集')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('検索機能', () => {
+    it('名前で検索できる', async () => {
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('山田太郎')).toBeInTheDocument();
+        expect(screen.getByText('佐藤花子')).toBeInTheDocument();
+      });
+
+      const searchInput = screen.getByPlaceholderText('名前またはエリアで検索...');
+      fireEvent.change(searchInput, { target: { value: '山田' } });
+
+      await waitFor(() => {
+        expect(screen.getByText('山田太郎')).toBeInTheDocument();
+        expect(screen.queryByText('佐藤花子')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('エリア読み込みエラー時', () => {
+    it('エリア読み込みエラーでもメンバー一覧は表示される', async () => {
+      areasResponse = {
+        data: undefined,
+        error: new Error('エリアの読み込みに失敗'),
+        isLoading: false,
+        mutate: jest.fn(),
+      };
+
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('山田太郎')).toBeInTheDocument();
+        expect(screen.getByText('佐藤花子')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('メンバー読み込みエラー時', () => {
+    it('エラーメッセージが表示される', async () => {
+      membersResponse = {
+        data: undefined,
+        error: new Error('メンバーの読み込みに失敗しました'),
+        isLoading: false,
+        mutate: mockMutate,
+      };
+
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('撮影者の読み込みに失敗しました')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/__tests__/app/members/page.test.tsx
+++ b/src/__tests__/app/members/page.test.tsx
@@ -109,6 +109,7 @@ jest.mock('@/src/context/ToastContext', () => ({
   useToast: () => ({
     showSuccess: mockShowSuccess,
     showError: mockShowError,
+    showWarning: jest.fn(),
     showErrorWithRetry: mockShowErrorWithRetry,
   }),
 }));
@@ -120,6 +121,70 @@ jest.mock('@/src/infra/http', () => ({
     delete: jest.fn(),
   },
 }));
+
+// MemberCardモック - 軽量化のため
+jest.mock('@/src/components/MemberCard', () => {
+  return function MockMemberCard({
+    member,
+    onDelete,
+    onEdit,
+  }: {
+    member: MemberStatus;
+    onDelete: (id: number) => void;
+    onEdit: (member: MemberStatus) => void;
+  }) {
+    return (
+      <div data-testid={`member-card-${member.id}`}>
+        <span>{member.name}</span>
+        <button aria-label="編集" onClick={() => onEdit(member)}>編集</button>
+        <button aria-label="削除" onClick={() => onDelete(member.id)}>削除</button>
+      </div>
+    );
+  };
+});
+
+// MemberEditDialogモック - 軽量化のため
+jest.mock('@/src/components/MemberEditDialog', () => {
+  return function MockMemberEditDialog({
+    open,
+    onClose,
+    onSave,
+    editingMember,
+    areas,
+    isSubmitting,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    onSave: (name: string, areaIds: number[], capacity: number) => Promise<void>;
+    editingMember: MemberStatus | null;
+    areas: Area[];
+    isSubmitting: boolean;
+  }) {
+    if (!open || !editingMember) return null;
+
+    const areaIds = editingMember.area
+      .map((areaName) => areas.find((a) => a.name === areaName)?.id)
+      .filter((id): id is number => id !== undefined);
+
+    return (
+      <div data-testid="member-edit-dialog">
+        <h2>メンバー編集</h2>
+        <input
+          aria-label="名前"
+          defaultValue={editingMember.name}
+          data-testid="name-input"
+        />
+        <button
+          disabled={isSubmitting}
+          onClick={() => void onSave(editingMember.name, areaIds, editingMember.capacity)}
+        >
+          更新
+        </button>
+        <button onClick={onClose}>キャンセル</button>
+      </div>
+    );
+  };
+});
 
 // テスト対象のページをインポート（モック設定後）
 import Members from '@/src/app/(admin)/members/page';
@@ -365,6 +430,26 @@ describe('Members Page', () => {
       await waitFor(() => {
         expect(screen.getByText('撮影者の読み込みに失敗しました')).toBeInTheDocument();
       });
+    });
+
+    it('再試行ボタンをクリックするとmutateが呼ばれる', async () => {
+      membersResponse = {
+        data: undefined,
+        error: new Error('メンバーの読み込みに失敗しました'),
+        isLoading: false,
+        mutate: mockMutate,
+      };
+
+      render(<Members />);
+
+      await waitFor(() => {
+        expect(screen.getByText('撮影者の読み込みに失敗しました')).toBeInTheDocument();
+      });
+
+      const retryButton = screen.getByRole('button', { name: '再試行' });
+      fireEvent.click(retryButton);
+
+      expect(mockMutate).toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/components/MemberCard.test.tsx
+++ b/src/__tests__/components/MemberCard.test.tsx
@@ -44,13 +44,13 @@ describe('MemberCard', () => {
     assign: 3,
   };
 
-  const mockHandleDelete = jest.fn();
-  const mockHandleEdit = jest.fn();
+  const mockOnDelete = jest.fn();
+  const mockOnEdit = jest.fn();
 
   const defaultProps = {
     member: mockMember,
-    handleDelete: mockHandleDelete,
-    onEdit: mockHandleEdit,
+    onDelete: mockOnDelete,
+    onEdit: mockOnEdit,
   };
 
   beforeEach(() => {
@@ -88,7 +88,7 @@ describe('MemberCard', () => {
       const editButton = screen.getByLabelText('編集');
       fireEvent.click(editButton);
 
-      expect(mockHandleEdit).toHaveBeenCalledWith(mockMember);
+      expect(mockOnEdit).toHaveBeenCalledWith(mockMember);
     });
   });
 
@@ -113,7 +113,7 @@ describe('MemberCard', () => {
       confirmSpy.mockRestore();
     });
 
-    it('削除成功時にhandleDeleteが呼ばれる', async () => {
+    it('削除成功時にonDeleteが呼ばれる', async () => {
       const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
       mockDeleteAccount.mockResolvedValue({ success: true });
       render(<MemberCard {...defaultProps} />);
@@ -122,7 +122,7 @@ describe('MemberCard', () => {
       fireEvent.click(deleteButton);
 
       await waitFor(() => {
-        expect(mockHandleDelete).toHaveBeenCalledWith(1);
+        expect(mockOnDelete).toHaveBeenCalledWith(1);
         expect(mockShowSuccess).toHaveBeenCalledWith('メンバーを削除しました');
       });
 

--- a/src/__tests__/components/MemberCard.test.tsx
+++ b/src/__tests__/components/MemberCard.test.tsx
@@ -158,6 +158,40 @@ describe('MemberCard', () => {
 
       confirmSpy.mockRestore();
     });
+
+    it('削除中は削除ボタンが無効化されダブルクリックを防ぐ', async () => {
+      let resolveDelete: (value: { success: boolean }) => void;
+      const deletePromise = new Promise<{ success: boolean }>((resolve) => {
+        resolveDelete = resolve;
+      });
+      mockDeleteAccount.mockReturnValue(deletePromise);
+
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+      render(<MemberCard {...defaultProps} />);
+
+      const deleteButton = screen.getByLabelText('メンバーを削除');
+
+      // 1回目のクリック
+      fireEvent.click(deleteButton);
+
+      // 削除中はボタンが無効化される
+      await waitFor(() => {
+        expect(deleteButton).toBeDisabled();
+      });
+
+      // 2回目のクリックは無視される
+      fireEvent.click(deleteButton);
+      expect(mockDeleteAccount).toHaveBeenCalledTimes(1);
+
+      // 削除完了
+      resolveDelete!({ success: true });
+
+      await waitFor(() => {
+        expect(deleteButton).not.toBeDisabled();
+      });
+
+      confirmSpy.mockRestore();
+    });
   });
 
   describe('NG率表示', () => {

--- a/src/__tests__/components/MemberCard.test.tsx
+++ b/src/__tests__/components/MemberCard.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * MemberCard テスト
+ *
+ * メンバーカードコンポーネント（編集ボタン追加対応）
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import MemberCard from '@/src/components/MemberCard';
+import { MemberStatus } from '@/src/types';
+
+// モック設定
+const mockDeleteAccount = jest.fn();
+const mockShowSuccess = jest.fn();
+const mockShowErrorWithRetry = jest.fn();
+
+jest.mock('@/src/mutations', () => ({
+  useAccountMutation: () => ({
+    deleteAccount: mockDeleteAccount,
+    updateAccount: jest.fn(),
+  }),
+}));
+
+jest.mock('@/src/context/ToastContext', () => ({
+  useToast: () => ({
+    showSuccess: mockShowSuccess,
+    showError: jest.fn(),
+    showErrorWithRetry: mockShowErrorWithRetry,
+  }),
+}));
+
+describe('MemberCard', () => {
+  const mockMember: MemberStatus = {
+    id: 1,
+    name: '山田太郎',
+    capacity: 5,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-02T00:00:00Z',
+    area: ['エリアA', 'エリアB'],
+    total: 50,
+    week: 5,
+    ng_rate: 0.1,
+    assign: 3,
+  };
+
+  const mockHandleDelete = jest.fn();
+  const mockHandleEdit = jest.fn();
+
+  const defaultProps = {
+    member: mockMember,
+    handleDelete: mockHandleDelete,
+    onEdit: mockHandleEdit,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDeleteAccount.mockResolvedValue({ success: true });
+  });
+
+  describe('基本表示', () => {
+    it('メンバー名が表示される', () => {
+      render(<MemberCard {...defaultProps} />);
+      expect(screen.getByText('山田太郎')).toBeInTheDocument();
+    });
+
+    it('エリアが表示される', () => {
+      render(<MemberCard {...defaultProps} />);
+      expect(screen.getByText('エリアA')).toBeInTheDocument();
+      expect(screen.getByText('エリアB')).toBeInTheDocument();
+    });
+
+    it('キャパシティが表示される', () => {
+      render(<MemberCard {...defaultProps} />);
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+  });
+
+  describe('編集ボタン', () => {
+    it('編集ボタンが表示される', () => {
+      render(<MemberCard {...defaultProps} />);
+      expect(screen.getByLabelText('編集')).toBeInTheDocument();
+    });
+
+    it('編集ボタンをクリックするとonEditが呼ばれる', () => {
+      render(<MemberCard {...defaultProps} />);
+
+      const editButton = screen.getByLabelText('編集');
+      fireEvent.click(editButton);
+
+      expect(mockHandleEdit).toHaveBeenCalledWith(mockMember);
+    });
+  });
+
+  describe('削除ボタン', () => {
+    it('削除ボタンが表示される', () => {
+      render(<MemberCard {...defaultProps} />);
+      expect(screen.getByLabelText('メンバーを削除')).toBeInTheDocument();
+    });
+
+    it('削除ボタンをクリックして確認するとdeleteAccountが呼ばれる', async () => {
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+      render(<MemberCard {...defaultProps} />);
+
+      const deleteButton = screen.getByLabelText('メンバーを削除');
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(confirmSpy).toHaveBeenCalledWith('山田太郎を削除しますか？');
+        expect(mockDeleteAccount).toHaveBeenCalledWith(1);
+      });
+
+      confirmSpy.mockRestore();
+    });
+
+    it('削除成功時にhandleDeleteが呼ばれる', async () => {
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+      mockDeleteAccount.mockResolvedValue({ success: true });
+      render(<MemberCard {...defaultProps} />);
+
+      const deleteButton = screen.getByLabelText('メンバーを削除');
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(mockHandleDelete).toHaveBeenCalledWith(1);
+        expect(mockShowSuccess).toHaveBeenCalledWith('メンバーを削除しました');
+      });
+
+      confirmSpy.mockRestore();
+    });
+
+    it('削除キャンセル時はdeleteAccountが呼ばれない', async () => {
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(false);
+      render(<MemberCard {...defaultProps} />);
+
+      const deleteButton = screen.getByLabelText('メンバーを削除');
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(confirmSpy).toHaveBeenCalled();
+        expect(mockDeleteAccount).not.toHaveBeenCalled();
+      });
+
+      confirmSpy.mockRestore();
+    });
+
+    it('削除失敗時にshowErrorWithRetryが呼ばれる', async () => {
+      const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+      mockDeleteAccount.mockResolvedValue({ success: false, error: '削除に失敗しました' });
+      render(<MemberCard {...defaultProps} />);
+
+      const deleteButton = screen.getByLabelText('メンバーを削除');
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => {
+        expect(mockShowErrorWithRetry).toHaveBeenCalled();
+      });
+
+      confirmSpy.mockRestore();
+    });
+  });
+
+  describe('NG率表示', () => {
+    it('NG率が正しく表示される', () => {
+      render(<MemberCard {...defaultProps} />);
+      expect(screen.getByText('10.0%')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/__tests__/components/MemberEditDialog.test.tsx
+++ b/src/__tests__/components/MemberEditDialog.test.tsx
@@ -1,0 +1,338 @@
+/**
+ * MemberEditDialog テスト
+ *
+ * メンバー編集ダイアログ
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import MemberEditDialog from '@/src/components/MemberEditDialog';
+import { Area, MemberStatus } from '@/src/types';
+
+// モック設定
+const mockAreas: Area[] = [
+  { id: 1, name: 'エリアA' },
+  { id: 2, name: 'エリアB' },
+  { id: 3, name: 'エリアC' },
+];
+
+jest.mock('@/src/api/get-areas', () => ({
+  getAreas: jest.fn().mockResolvedValue([
+    { id: 1, name: 'エリアA' },
+    { id: 2, name: 'エリアB' },
+    { id: 3, name: 'エリアC' },
+  ]),
+}));
+
+jest.mock('@/src/context/ToastContext', () => ({
+  useToast: () => ({
+    showSuccess: jest.fn(),
+    showError: jest.fn(),
+    showErrorWithRetry: jest.fn(),
+  }),
+}));
+
+/**
+ * MUI TextFieldの入力要素を取得するヘルパー
+ */
+const getNameInput = (): HTMLInputElement => {
+  return screen.getByRole('textbox', { name: /名前/ }) as HTMLInputElement;
+};
+
+const getCapacityInput = (): HTMLInputElement => {
+  return screen.getByRole('spinbutton', { name: /1日の最大撮影数/ }) as HTMLInputElement;
+};
+
+describe('MemberEditDialog', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSave = jest.fn();
+
+  const mockMember: MemberStatus = {
+    id: 1,
+    name: '山田太郎',
+    capacity: 5,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-02T00:00:00Z',
+    area: ['エリアA', 'エリアB'],
+    total: 50,
+    week: 5,
+    ng_rate: 0.1,
+    assign: 3,
+  };
+
+  const defaultProps = {
+    open: true,
+    onClose: mockOnClose,
+    onSave: mockOnSave,
+    editingMember: mockMember,
+    isSubmitting: false,
+    areas: mockAreas,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOnSave.mockResolvedValue(undefined);
+  });
+
+  describe('初期表示', () => {
+    it('「メンバー編集」タイトルが表示される', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText('メンバー編集')).toBeInTheDocument();
+      });
+    });
+
+    it('名前入力フィールドにメンバー名が表示される', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+      await waitFor(() => {
+        const input = getNameInput();
+        expect(input).toHaveValue('山田太郎');
+      });
+    });
+
+    it('キャパシティ入力フィールドに値が表示される', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+      await waitFor(() => {
+        const input = getCapacityInput();
+        expect(input).toHaveValue(5);
+      });
+    });
+
+    it('保存ボタンのテキストが「更新」になる', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: '更新' })).toBeInTheDocument();
+      });
+    });
+
+    it('エリアチェックボックスが表示される', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByLabelText('エリアA')).toBeInTheDocument();
+        expect(screen.getByLabelText('エリアB')).toBeInTheDocument();
+        expect(screen.getByLabelText('エリアC')).toBeInTheDocument();
+      });
+    });
+
+    it('既存のエリアがチェックされている', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+      await waitFor(() => {
+        const areaACheckbox = screen.getByLabelText('エリアA');
+        const areaBCheckbox = screen.getByLabelText('エリアB');
+        const areaCCheckbox = screen.getByLabelText('エリアC');
+        expect(areaACheckbox).toBeChecked();
+        expect(areaBCheckbox).toBeChecked();
+        expect(areaCCheckbox).not.toBeChecked();
+      });
+    });
+  });
+
+  describe('バリデーション', () => {
+    it('空の名前でエラーメッセージが表示される', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const input = getNameInput();
+        fireEvent.change(input, { target: { value: '' } });
+      });
+
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      fireEvent.click(updateButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('名前は必須です')).toBeInTheDocument();
+      });
+      expect(mockOnSave).not.toHaveBeenCalled();
+    });
+
+    it('32文字を超える名前でエラーメッセージが表示される', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const input = getNameInput();
+        fireEvent.change(input, { target: { value: 'あ'.repeat(33) } });
+      });
+
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      fireEvent.click(updateButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('名前は32文字以内で入力してください')).toBeInTheDocument();
+      });
+      expect(mockOnSave).not.toHaveBeenCalled();
+    });
+
+    it('負のキャパシティでエラーメッセージが表示される', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const input = getCapacityInput();
+        fireEvent.change(input, { target: { value: '-1' } });
+      });
+
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      fireEvent.click(updateButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('1日の最大撮影数は0以上で入力してください')).toBeInTheDocument();
+      });
+      expect(mockOnSave).not.toHaveBeenCalled();
+    });
+
+    it('有効な入力でonSaveが呼ばれる', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const input = getNameInput();
+        expect(input).toHaveValue('山田太郎');
+      });
+
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      fireEvent.click(updateButton);
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith('山田太郎', [1, 2], 5);
+      });
+    });
+  });
+
+  describe('エリア選択の変更', () => {
+    it('エリアのチェックを外すと選択から除外される', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const areaACheckbox = screen.getByLabelText('エリアA');
+        fireEvent.click(areaACheckbox);
+      });
+
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      fireEvent.click(updateButton);
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith('山田太郎', [2], 5);
+      });
+    });
+
+    it('新しいエリアをチェックすると選択に追加される', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const areaCCheckbox = screen.getByLabelText('エリアC');
+        fireEvent.click(areaCCheckbox);
+      });
+
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      fireEvent.click(updateButton);
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith('山田太郎', [1, 2, 3], 5);
+      });
+    });
+
+    it('すべてのエリアを外しても更新できる', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const areaACheckbox = screen.getByLabelText('エリアA');
+        const areaBCheckbox = screen.getByLabelText('エリアB');
+        fireEvent.click(areaACheckbox);
+        fireEvent.click(areaBCheckbox);
+      });
+
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      fireEvent.click(updateButton);
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith('山田太郎', [], 5);
+      });
+    });
+  });
+
+  describe('送信中の状態', () => {
+    it('送信中はボタンが無効化される', async () => {
+      render(<MemberEditDialog {...defaultProps} isSubmitting={true} />);
+
+      await waitFor(() => {
+        const updateButton = screen.getByRole('button', { name: '更新中...' });
+        expect(updateButton).toBeDisabled();
+      });
+    });
+
+    it('送信中は入力フィールドが無効化される', async () => {
+      render(<MemberEditDialog {...defaultProps} isSubmitting={true} />);
+
+      await waitFor(() => {
+        const nameInput = getNameInput();
+        const capacityInput = getCapacityInput();
+        expect(nameInput).toBeDisabled();
+        expect(capacityInput).toBeDisabled();
+      });
+    });
+  });
+
+  describe('キャンセル操作', () => {
+    it('キャンセルボタンでonCloseが呼ばれる', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+        fireEvent.click(cancelButton);
+      });
+
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    it('送信中はキャンセルボタンも無効化される', async () => {
+      render(<MemberEditDialog {...defaultProps} isSubmitting={true} />);
+
+      await waitFor(() => {
+        const cancelButton = screen.getByRole('button', { name: 'キャンセル' });
+        expect(cancelButton).toBeDisabled();
+      });
+    });
+  });
+
+  describe('ダイアログが閉じているとき', () => {
+    it('ダイアログが表示されない', () => {
+      render(<MemberEditDialog {...defaultProps} open={false} />);
+      expect(screen.queryByText('メンバー編集')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('入力値のトリム', () => {
+    it('名前の前後の空白をトリムしてonSaveを呼ぶ', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const input = getNameInput();
+        fireEvent.change(input, { target: { value: '  テスト太郎  ' } });
+      });
+
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      fireEvent.click(updateButton);
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith('テスト太郎', [1, 2], 5);
+      });
+    });
+  });
+
+  describe('キャパシティ0の場合', () => {
+    it('キャパシティ0で更新できる', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const input = getCapacityInput();
+        fireEvent.change(input, { target: { value: '0' } });
+      });
+
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      fireEvent.click(updateButton);
+
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith('山田太郎', [1, 2], 0);
+      });
+    });
+  });
+});

--- a/src/__tests__/components/MemberEditDialog.test.tsx
+++ b/src/__tests__/components/MemberEditDialog.test.tsx
@@ -33,6 +33,12 @@ jest.mock('@/src/context/ToastContext', () => ({
   }),
 }));
 
+jest.mock('@/src/util/safe-logger', () => ({
+  logError: jest.fn(),
+  logWarn: jest.fn(),
+  logDebug: jest.fn(),
+}));
+
 /**
  * MUI TextFieldの入力要素を取得するヘルパー
  */
@@ -175,7 +181,24 @@ describe('MemberEditDialog', () => {
       fireEvent.click(updateButton);
 
       await waitFor(() => {
-        expect(screen.getByText('1日の最大撮影数は0以上で入力してください')).toBeInTheDocument();
+        expect(screen.getByText('1日の最大撮影数は0以上1000以下の整数で入力してください')).toBeInTheDocument();
+      });
+      expect(mockOnSave).not.toHaveBeenCalled();
+    });
+
+    it('キャパシティが上限を超えるとエラーメッセージが表示される', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const input = getCapacityInput();
+        fireEvent.change(input, { target: { value: '1001' } });
+      });
+
+      const updateButton = screen.getByRole('button', { name: '更新' });
+      fireEvent.click(updateButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('1日の最大撮影数は0以上1000以下の整数で入力してください')).toBeInTheDocument();
       });
       expect(mockOnSave).not.toHaveBeenCalled();
     });

--- a/src/__tests__/components/MemberEditDialog.test.tsx
+++ b/src/__tests__/components/MemberEditDialog.test.tsx
@@ -17,14 +17,6 @@ const mockAreas: Area[] = [
   { id: 3, name: 'エリアC' },
 ];
 
-jest.mock('@/src/api/get-areas', () => ({
-  getAreas: jest.fn().mockResolvedValue([
-    { id: 1, name: 'エリアA' },
-    { id: 2, name: 'エリアB' },
-    { id: 3, name: 'エリアC' },
-  ]),
-}));
-
 jest.mock('@/src/context/ToastContext', () => ({
   useToast: () => ({
     showSuccess: jest.fn(),

--- a/src/__tests__/components/MemberEditDialog.test.tsx
+++ b/src/__tests__/components/MemberEditDialog.test.tsx
@@ -17,10 +17,13 @@ const mockAreas: Area[] = [
   { id: 3, name: 'エリアC' },
 ];
 
+const mockShowWarning = jest.fn();
+
 jest.mock('@/src/context/ToastContext', () => ({
   useToast: () => ({
     showSuccess: jest.fn(),
     showError: jest.fn(),
+    showWarning: mockShowWarning,
     showErrorWithRetry: jest.fn(),
   }),
 }));
@@ -71,6 +74,7 @@ describe('MemberEditDialog', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockOnSave.mockResolvedValue(undefined);
+    mockShowWarning.mockClear();
   });
 
   describe('初期表示', () => {
@@ -360,6 +364,74 @@ describe('MemberEditDialog', () => {
 
       await waitFor(() => {
         expect(mockOnSave).toHaveBeenCalledWith('山田太郎', [1, 2], 0);
+      });
+    });
+  });
+
+  describe('エリア情報が空の場合', () => {
+    it('エリアが空配列の場合はエラーメッセージが表示される', async () => {
+      render(<MemberEditDialog {...defaultProps} areas={[]} />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('エリア情報を読み込めませんでした。ダイアログを閉じて再試行してください。'),
+        ).toBeInTheDocument();
+      });
+
+      // チェックボックスが表示されないことを確認
+      expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('エリアマッピング', () => {
+    it('存在しないエリア名がある場合はlogErrorとshowWarningが呼ばれる', async () => {
+      const { logError } = jest.requireMock('@/src/util/safe-logger');
+      const memberWithUnknownArea: MemberStatus = {
+        ...mockMember,
+        area: ['エリアA', '未知のエリア', '存在しないエリア'],
+      };
+
+      render(<MemberEditDialog {...defaultProps} editingMember={memberWithUnknownArea} />);
+
+      await waitFor(() => {
+        expect(logError).toHaveBeenCalledWith(
+          '[MemberEditDialog] エリア名のマッピングに失敗',
+          expect.objectContaining({
+            memberId: memberWithUnknownArea.id,
+            memberName: memberWithUnknownArea.name,
+            unmappedAreas: ['未知のエリア', '存在しないエリア'],
+          }),
+        );
+        expect(mockShowWarning).toHaveBeenCalledWith(
+          '次のエリアは選択リストにありません: 未知のエリア, 存在しないエリア',
+        );
+      });
+    });
+
+    it('すべてのエリアがマッピングできる場合はlogErrorもshowWarningも呼ばれない', async () => {
+      const { logError } = jest.requireMock('@/src/util/safe-logger');
+
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('エリアA')).toBeInTheDocument();
+      });
+
+      expect(logError).not.toHaveBeenCalledWith(
+        '[MemberEditDialog] エリア名のマッピングに失敗',
+        expect.anything(),
+      );
+      expect(mockShowWarning).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('送信中のチェックボックス状態', () => {
+    it('送信中はエリアチェックボックスも無効化される', async () => {
+      render(<MemberEditDialog {...defaultProps} isSubmitting={true} />);
+
+      await waitFor(() => {
+        const areaACheckbox = screen.getByLabelText('エリアA');
+        expect(areaACheckbox).toBeDisabled();
       });
     });
   });

--- a/src/__tests__/components/MemberEditDialog.test.tsx
+++ b/src/__tests__/components/MemberEditDialog.test.tsx
@@ -435,4 +435,71 @@ describe('MemberEditDialog', () => {
       });
     });
   });
+
+  describe('areasの再検証時のフォームリセット防止', () => {
+    it('areasが変更されても編集中の入力値がリセットされない', async () => {
+      const { rerender } = render(<MemberEditDialog {...defaultProps} />);
+
+      // 初期値を確認
+      await waitFor(() => {
+        expect(getNameInput()).toHaveValue('山田太郎');
+        expect(getCapacityInput()).toHaveValue(5);
+      });
+
+      // ユーザーが入力値を変更
+      fireEvent.change(getNameInput(), { target: { value: '変更後の名前' } });
+      fireEvent.change(getCapacityInput(), { target: { value: '10' } });
+
+      expect(getNameInput()).toHaveValue('変更後の名前');
+      expect(getCapacityInput()).toHaveValue(10);
+
+      // SWRの再検証でareasの参照が変わる（同じ内容の新しい配列）
+      const newAreas: Area[] = [
+        { id: 1, name: 'エリアA' },
+        { id: 2, name: 'エリアB' },
+        { id: 3, name: 'エリアC' },
+      ];
+      rerender(<MemberEditDialog {...defaultProps} areas={newAreas} />);
+
+      // 編集中の入力値がリセットされていないことを確認
+      expect(getNameInput()).toHaveValue('変更後の名前');
+      expect(getCapacityInput()).toHaveValue(10);
+    });
+
+    it('ダイアログを閉じて再度開くと新しいメンバーで初期化される', async () => {
+      const { rerender } = render(<MemberEditDialog {...defaultProps} />);
+
+      // 初期値を確認
+      await waitFor(() => {
+        expect(getNameInput()).toHaveValue('山田太郎');
+      });
+
+      // 入力値を変更
+      fireEvent.change(getNameInput(), { target: { value: '変更後の名前' } });
+
+      // ダイアログを閉じる
+      rerender(<MemberEditDialog {...defaultProps} open={false} />);
+
+      // 別のメンバーで再度開く
+      const anotherMember: MemberStatus = {
+        id: 2,
+        name: '佐藤花子',
+        capacity: 3,
+        createdAt: '2024-01-01T00:00:00Z',
+        updatedAt: '2024-01-02T00:00:00Z',
+        area: ['エリアC'],
+        total: 30,
+        week: 3,
+        ng_rate: 0.05,
+        assign: 2,
+      };
+      rerender(<MemberEditDialog {...defaultProps} open={true} editingMember={anotherMember} />);
+
+      // 新しいメンバーのデータで初期化されることを確認
+      await waitFor(() => {
+        expect(getNameInput()).toHaveValue('佐藤花子');
+        expect(getCapacityInput()).toHaveValue(3);
+      });
+    });
+  });
 });

--- a/src/__tests__/components/MemberEditDialog.test.tsx
+++ b/src/__tests__/components/MemberEditDialog.test.tsx
@@ -195,6 +195,19 @@ describe('MemberEditDialog', () => {
       expect(mockOnSave).not.toHaveBeenCalled();
     });
 
+    it('小数のキャパシティ入力で即座にエラーメッセージが表示される', async () => {
+      render(<MemberEditDialog {...defaultProps} />);
+
+      await waitFor(() => {
+        const input = getCapacityInput();
+        fireEvent.change(input, { target: { value: '1.5' } });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('1日の最大撮影数は0以上1000以下の整数で入力してください')).toBeInTheDocument();
+      });
+    });
+
     it('有効な入力でonSaveが呼ばれる', async () => {
       render(<MemberEditDialog {...defaultProps} />);
 

--- a/src/__tests__/infra/http/client.test.ts
+++ b/src/__tests__/infra/http/client.test.ts
@@ -14,7 +14,7 @@ describe('httpClient', () => {
       const mockData = { id: 1, name: 'Test' };
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(mockData),
+        text: () => Promise.resolve(JSON.stringify(mockData)),
       });
 
       const result = await httpClient.get('/api/test');
@@ -166,7 +166,7 @@ describe('httpClient', () => {
     test('passes headers when provided', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(JSON.stringify({})),
       });
 
       await httpClient.get('/api/test', {
@@ -186,7 +186,7 @@ describe('httpClient', () => {
       const mockData = { id: 1 };
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(mockData),
+        text: () => Promise.resolve(JSON.stringify(mockData)),
       });
 
       const result = await httpClient.post('/api/test', { name: 'Test' });
@@ -222,7 +222,7 @@ describe('httpClient', () => {
     test('handles post without body', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(JSON.stringify({})),
       });
 
       await httpClient.post('/api/test');

--- a/src/__tests__/infra/http/client.test.ts
+++ b/src/__tests__/infra/http/client.test.ts
@@ -163,6 +163,35 @@ describe('httpClient', () => {
       await expect(httpClient.get('/api/test')).rejects.toThrow('Aborted');
     });
 
+    test('returns 502 error when JSON parsing fails on successful response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('invalid json {'),
+      });
+
+      const result = await httpClient.get('/api/test');
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.status).toBe(502);
+        expect(result.error.message).toBe('サーバーからの応答を解析できませんでした');
+      }
+    });
+
+    test('returns empty object on successful empty response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(''),
+      });
+
+      const result = await httpClient.get('/api/test');
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual({});
+      }
+    });
+
     test('passes headers when provided', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -234,6 +263,35 @@ describe('httpClient', () => {
         body: undefined,
       });
     });
+
+    test('returns 502 error when JSON parsing fails on successful response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('not valid json'),
+      });
+
+      const result = await httpClient.post('/api/test', { name: 'Test' });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.status).toBe(502);
+        expect(result.error.message).toBe('サーバーからの応答を解析できませんでした');
+      }
+    });
+
+    test('returns empty object on successful empty response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve(''),
+      });
+
+      const result = await httpClient.post('/api/test', { name: 'Test' });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value).toEqual({});
+      }
+    });
   });
 
   describe('put', () => {
@@ -277,7 +335,7 @@ describe('httpClient', () => {
       // 非JSONレスポンスはエラーとして扱う（サイレント失敗防止）
       expect(result.ok).toBe(false);
       if (!result.ok) {
-        expect(result.error.message).toBe('Invalid JSON response from server');
+        expect(result.error.message).toBe('サーバーからの応答を解析できませんでした');
       }
     });
   });

--- a/src/__tests__/mutations/useAccountMutation.test.ts
+++ b/src/__tests__/mutations/useAccountMutation.test.ts
@@ -6,6 +6,7 @@ import { httpClient } from '@/src/infra/http';
 jest.mock('@/src/infra/http', () => ({
   httpClient: {
     delete: jest.fn(),
+    put: jest.fn(),
   },
 }));
 
@@ -14,6 +15,125 @@ const mockHttpClient = httpClient as jest.Mocked<typeof httpClient>;
 describe('useAccountMutation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('updateAccount', () => {
+    const mockMemberStatus = {
+      id: 1,
+      name: '更新メンバー',
+      capacity: 10,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-02T00:00:00Z',
+      area: ['エリアA'],
+      total: 50,
+      week: 5,
+      ng_rate: 0.1,
+      assign: 3,
+    };
+
+    test('returns success result on successful update', async () => {
+      mockHttpClient.put.mockResolvedValueOnce({
+        ok: true,
+        value: mockMemberStatus,
+      });
+
+      const { result } = renderHook(() => useAccountMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.updateAccount(1, '更新メンバー', [1], 10);
+      });
+
+      expect(response).toEqual({ success: true, data: mockMemberStatus });
+      expect(mockHttpClient.put).toHaveBeenCalledWith('/api/account', {
+        id: 1,
+        name: '更新メンバー',
+        area: [1],
+        capacity: 10,
+      });
+    });
+
+    test('returns error result with errorType and statusCode on API failure', async () => {
+      mockHttpClient.put.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'api', status: 404, message: 'アカウントが見つかりません' },
+      });
+
+      const { result } = renderHook(() => useAccountMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.updateAccount(999, 'テスト', [], 5);
+      });
+
+      expect(response).toEqual({
+        success: false,
+        error: 'アカウントが見つかりません',
+        errorType: 'api',
+        statusCode: 404,
+      });
+    });
+
+    test('returns error result with errorType on network failure', async () => {
+      mockHttpClient.put.mockResolvedValueOnce({
+        ok: false,
+        error: { type: 'network', message: 'ネットワークエラーが発生しました' },
+      });
+
+      const { result } = renderHook(() => useAccountMutation());
+
+      let response;
+      await act(async () => {
+        response = await result.current.updateAccount(1, 'テスト', [], 5);
+      });
+
+      expect(response).toEqual({
+        success: false,
+        error: 'ネットワークエラーが発生しました',
+        errorType: 'network',
+        statusCode: undefined,
+      });
+    });
+
+    test('handles empty area array', async () => {
+      mockHttpClient.put.mockResolvedValueOnce({
+        ok: true,
+        value: { ...mockMemberStatus, area: [] },
+      });
+
+      const { result } = renderHook(() => useAccountMutation());
+
+      await act(async () => {
+        await result.current.updateAccount(1, 'テスト', [], 5);
+      });
+
+      expect(mockHttpClient.put).toHaveBeenCalledWith('/api/account', {
+        id: 1,
+        name: 'テスト',
+        area: [],
+        capacity: 5,
+      });
+    });
+
+    test('handles multiple area IDs', async () => {
+      mockHttpClient.put.mockResolvedValueOnce({
+        ok: true,
+        value: mockMemberStatus,
+      });
+
+      const { result } = renderHook(() => useAccountMutation());
+
+      await act(async () => {
+        await result.current.updateAccount(1, 'テスト', [1, 2, 3], 5);
+      });
+
+      expect(mockHttpClient.put).toHaveBeenCalledWith('/api/account', {
+        id: 1,
+        name: 'テスト',
+        area: [1, 2, 3],
+        capacity: 5,
+      });
+    });
   });
 
   describe('deleteAccount', () => {
@@ -117,10 +237,12 @@ describe('useAccountMutation', () => {
     });
   });
 
-  test('hook returns deleteAccount function', () => {
+  test('hook returns deleteAccount and updateAccount functions', () => {
     const { result } = renderHook(() => useAccountMutation());
 
     expect(result.current.deleteAccount).toBeDefined();
     expect(typeof result.current.deleteAccount).toBe('function');
+    expect(result.current.updateAccount).toBeDefined();
+    expect(typeof result.current.updateAccount).toBe('function');
   });
 });

--- a/src/app/(admin)/members/page.tsx
+++ b/src/app/(admin)/members/page.tsx
@@ -96,6 +96,7 @@ const Members = () => {
   // 編集ダイアログを開く
   const handleOpenEdit = useCallback((member: MemberStatus) => {
     if (areasError) {
+      logError('[MembersPage:handleOpenEdit] Edit blocked due to areas fetch failure', areasError);
       showError('エリア情報の読み込みに失敗したため、編集できません');
       return;
     }

--- a/src/app/(admin)/members/page.tsx
+++ b/src/app/(admin)/members/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import AddIcon from '@mui/icons-material/Add';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import GroupIcon from '@mui/icons-material/Group';
 import SearchIcon from '@mui/icons-material/Search';
 import {
@@ -15,45 +16,120 @@ import {
   Typography,
 } from '@mui/material';
 import Link from 'next/link';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import useSWR from 'swr';
 
-import { getAccountStatus } from '@/src/api/get-account-status';
 import MemberCard from '@/src/components/MemberCard';
-import { MemberStatus } from '@/src/types';
+import MemberEditDialog from '@/src/components/MemberEditDialog';
+import { useToast } from '@/src/context/ToastContext';
+import { httpClient } from '@/src/infra/http';
+import { useAccountMutation } from '@/src/mutations';
+import { Area, MemberStatus } from '@/src/types';
+import { logError } from '@/src/util/safe-logger';
+
+/**
+ * メンバーデータのフェッチャー
+ */
+const membersFetcher = async (): Promise<MemberStatus[]> => {
+  const result = await httpClient.get<MemberStatus[]>('/api/accounts');
+  if (!result.ok) {
+    logError('[MembersPage:membersFetcher]', result.error);
+    throw new Error(result.error.message);
+  }
+  return result.value;
+};
+
+/**
+ * エリアデータのフェッチャー
+ */
+const areasFetcher = async (): Promise<Area[]> => {
+  const result = await httpClient.get<Area[]>('/api/areas');
+  if (!result.ok) {
+    logError('[MembersPage:areasFetcher]', result.error);
+    throw new Error(result.error.message);
+  }
+  return result.value;
+};
 
 const Members = () => {
-  const [membersStatus, setMembersStatus] = useState<MemberStatus[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const {
+    data: members,
+    error: membersError,
+    isLoading: membersLoading,
+    mutate,
+  } = useSWR<MemberStatus[], Error>('members', membersFetcher);
+  const { data: areas, isLoading: areasLoading } = useSWR<Area[], Error>('areas', areasFetcher);
+
+  const { updateAccount } = useAccountMutation();
+  const { showSuccess, showErrorWithRetry } = useToast();
+
   const [searchQuery, setSearchQuery] = useState('');
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingMember, setEditingMember] = useState<MemberStatus | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      setIsLoading(true);
-      const response = await getAccountStatus();
-
-      if (response !== undefined) {
-        setMembersStatus(response as MemberStatus[]);
-      }
-      setIsLoading(false);
-    };
-
-    void fetchData();
-  }, []);
-
-  const handleDelete = useCallback((id: number) => {
-    setMembersStatus((prev) => prev.filter((member) => member.id !== id));
-  }, []);
+  const isLoading = membersLoading || areasLoading;
 
   // 検索フィルタリング
   const filteredMembers = useMemo(() => {
-    if (!searchQuery.trim()) return membersStatus;
+    if (!members) return [];
+    if (!searchQuery.trim()) return members;
     const query = searchQuery.toLowerCase();
-    return membersStatus.filter(
+    return members.filter(
       (member) =>
         member.name.toLowerCase().includes(query) ||
         member.area.some((area) => area.toLowerCase().includes(query)),
     );
-  }, [membersStatus, searchQuery]);
+  }, [members, searchQuery]);
+
+  // 削除ハンドラー（ローカルの楽観的更新）
+  const handleDelete = useCallback(
+    (id: number) => {
+      void mutate(
+        (current) => current?.filter((member) => member.id !== id),
+        false,
+      );
+    },
+    [mutate],
+  );
+
+  // 編集ダイアログを開く
+  const handleOpenEdit = useCallback((member: MemberStatus) => {
+    setEditingMember(member);
+    setDialogOpen(true);
+  }, []);
+
+  // ダイアログを閉じる
+  const handleCloseDialog = useCallback(() => {
+    setDialogOpen(false);
+    setEditingMember(null);
+  }, []);
+
+  // 保存処理
+  const handleSave = useCallback(
+    async (name: string, areaIds: number[], capacity: number) => {
+      if (!editingMember) return;
+
+      setIsSubmitting(true);
+      try {
+        const result = await updateAccount(editingMember.id, name, areaIds, capacity);
+        if (result.success) {
+          showSuccess('メンバーを更新しました');
+          handleCloseDialog();
+          void mutate();
+        } else {
+          showErrorWithRetry(result.error ?? '更新に失敗しました', () =>
+            void handleSave(name, areaIds, capacity),
+          );
+        }
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [editingMember, updateAccount, showSuccess, showErrorWithRetry, handleCloseDialog, mutate],
+  );
+
+  const memberCount = members?.length ?? 0;
 
   return (
     <Box
@@ -103,7 +179,7 @@ const Members = () => {
                   撮影者管理
                 </Typography>
                 <Typography sx={{ opacity: 0.9, fontSize: '0.875rem' }}>
-                  {isLoading ? '読み込み中...' : `${membersStatus.length}名の撮影者が登録されています`}
+                  {isLoading ? '読み込み中...' : `${memberCount}名の撮影者が登録されています`}
                 </Typography>
               </Box>
             </Box>
@@ -174,8 +250,36 @@ const Members = () => {
           </Box>
         )}
 
+        {/* エラー状態 */}
+        {membersError && !isLoading && (
+          <Paper
+            elevation={0}
+            sx={{
+              p: 6,
+              textAlign: 'center',
+              borderRadius: 3,
+              bgcolor: 'white',
+            }}
+          >
+            <ErrorOutlineIcon sx={{ fontSize: 64, color: 'error.main', mb: 2 }} />
+            <Typography color="text.secondary" variant="h6">
+              撮影者の読み込みに失敗しました
+            </Typography>
+            <Typography color="text.secondary" sx={{ mt: 1 }} variant="body2">
+              {membersError instanceof Error ? membersError.message : '不明なエラーが発生しました'}
+            </Typography>
+            <Button
+              onClick={() => void mutate()}
+              sx={{ mt: 2 }}
+              variant="contained"
+            >
+              再試行
+            </Button>
+          </Paper>
+        )}
+
         {/* メンバーカードグリッド */}
-        {!isLoading && (
+        {!isLoading && !membersError && filteredMembers.length > 0 && (
           <Box
             sx={{
               display: 'grid',
@@ -192,13 +296,14 @@ const Members = () => {
                 handleDelete={handleDelete}
                 key={memberStatus.id}
                 member={memberStatus}
+                onEdit={handleOpenEdit}
               />
             ))}
           </Box>
         )}
 
-        {/* 検索結果なし */}
-        {!isLoading && filteredMembers.length === 0 && (
+        {/* 検索結果なし / 空状態 */}
+        {!isLoading && !membersError && filteredMembers.length === 0 && (
           <Paper
             elevation={0}
             sx={{
@@ -228,6 +333,16 @@ const Members = () => {
           </Paper>
         )}
       </Container>
+
+      {/* 編集ダイアログ */}
+      <MemberEditDialog
+        areas={areas ?? []}
+        editingMember={editingMember}
+        isSubmitting={isSubmitting}
+        onClose={handleCloseDialog}
+        onSave={handleSave}
+        open={dialogOpen}
+      />
     </Box>
   );
 };

--- a/src/app/(admin)/members/page.tsx
+++ b/src/app/(admin)/members/page.tsx
@@ -126,11 +126,14 @@ const Members = () => {
             void handleSave(name, areaIds, capacity),
           );
         }
+      } catch (error) {
+        logError('[MembersPage:handleSave] Unexpected error', error);
+        showError('予期せぬエラーが発生しました。ページを再読み込みしてください。');
       } finally {
         setIsSubmitting(false);
       }
     },
-    [editingMember, updateAccount, showSuccess, showErrorWithRetry, handleCloseDialog, mutate],
+    [editingMember, updateAccount, showSuccess, showError, showErrorWithRetry, handleCloseDialog, mutate],
   );
 
   const memberCount = members?.length ?? 0;

--- a/src/app/(admin)/members/page.tsx
+++ b/src/app/(admin)/members/page.tsx
@@ -58,10 +58,10 @@ const Members = () => {
     isLoading: membersLoading,
     mutate,
   } = useSWR<MemberStatus[], Error>('members', membersFetcher);
-  const { data: areas, isLoading: areasLoading } = useSWR<Area[], Error>('areas', areasFetcher);
+  const { data: areas, error: areasError, isLoading: areasLoading } = useSWR<Area[], Error>('areas', areasFetcher);
 
   const { updateAccount } = useAccountMutation();
-  const { showSuccess, showErrorWithRetry } = useToast();
+  const { showSuccess, showError, showErrorWithRetry } = useToast();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -95,9 +95,13 @@ const Members = () => {
 
   // 編集ダイアログを開く
   const handleOpenEdit = useCallback((member: MemberStatus) => {
+    if (areasError) {
+      showError('エリア情報の読み込みに失敗したため、編集できません');
+      return;
+    }
     setEditingMember(member);
     setDialogOpen(true);
-  }, []);
+  }, [areasError, showError]);
 
   // ダイアログを閉じる
   const handleCloseDialog = useCallback(() => {

--- a/src/app/(admin)/members/page.tsx
+++ b/src/app/(admin)/members/page.tsx
@@ -82,7 +82,8 @@ const Members = () => {
     );
   }, [members, searchQuery]);
 
-  // 削除ハンドラー: SWRキャッシュを楽観的に更新後、サーバーと同期
+  // 削除成功後のコールバック: ローカルキャッシュから削除し、サーバーと再同期
+  // 注: 実際のDELETE APIはMemberCardコンポーネント内で実行される
   const handleDelete = useCallback(
     (id: number) => {
       void mutate(

--- a/src/app/(admin)/members/page.tsx
+++ b/src/app/(admin)/members/page.tsx
@@ -306,9 +306,9 @@ const Members = () => {
           >
             {filteredMembers.map((memberStatus) => (
               <MemberCard
-                handleDelete={handleDelete}
                 key={memberStatus.id}
                 member={memberStatus}
+                onDelete={handleDelete}
                 onEdit={handleOpenEdit}
               />
             ))}

--- a/src/app/(admin)/members/page.tsx
+++ b/src/app/(admin)/members/page.tsx
@@ -82,12 +82,12 @@ const Members = () => {
     );
   }, [members, searchQuery]);
 
-  // 削除ハンドラー（ローカルの楽観的更新）
+  // 削除ハンドラー: SWRキャッシュを楽観的に更新後、サーバーと同期
   const handleDelete = useCallback(
     (id: number) => {
       void mutate(
         (current) => current?.filter((member) => member.id !== id),
-        false,
+        { revalidate: true },
       );
     },
     [mutate],
@@ -95,6 +95,10 @@ const Members = () => {
 
   // 編集ダイアログを開く
   const handleOpenEdit = useCallback((member: MemberStatus) => {
+    if (areasLoading) {
+      showError('エリア情報を読み込み中です。しばらくお待ちください。');
+      return;
+    }
     if (areasError) {
       logError('[MembersPage:handleOpenEdit] Edit blocked due to areas fetch failure', areasError);
       showError('エリア情報の読み込みに失敗したため、編集できません');
@@ -102,7 +106,7 @@ const Members = () => {
     }
     setEditingMember(member);
     setDialogOpen(true);
-  }, [areasError, showError]);
+  }, [areasLoading, areasError, showError]);
 
   // ダイアログを閉じる
   const handleCloseDialog = useCallback(() => {

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -12,6 +12,9 @@ import { logError } from '@/src/util/safe-logger';
 /** 名前の最大文字数 */
 const MAX_NAME_LENGTH = 32;
 
+/** キャパシティの最大値 */
+const MAX_CAPACITY = 1000;
+
 type UpdateBody = {
   id: number;
   name: string;
@@ -61,8 +64,8 @@ const validateAreaArray = (area: unknown): { valid: true } | { valid: false; err
  * キャパシティのバリデーション
  */
 const validateCapacity = (capacity: unknown): { valid: true } | { valid: false; error: string } => {
-  if (!Number.isInteger(capacity) || (capacity as number) < 0) {
-    return { valid: false, error: 'キャパシティは0以上の整数で指定してください' };
+  if (!Number.isInteger(capacity) || (capacity as number) < 0 || (capacity as number) > MAX_CAPACITY) {
+    return { valid: false, error: `1日の最大撮影数は0以上${MAX_CAPACITY}以下の整数で入力してください` };
   }
   return { valid: true };
 };

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -1,0 +1,157 @@
+/**
+ * Account API Route Handler
+ *
+ * PUT /api/account - メンバー情報更新
+ */
+import { NextRequest, NextResponse } from 'next/server';
+
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
+import { requireAdmin, requireAuth } from '@/src/util/route-helpers';
+import { logError } from '@/src/util/safe-logger';
+
+/** 名前の最大文字数 */
+const MAX_NAME_LENGTH = 32;
+
+type UpdateBody = {
+  id: number;
+  name: string;
+  area: number[];
+  capacity: number;
+};
+
+/**
+ * 名前のバリデーション
+ */
+const validateName = (name: unknown): { valid: true } | { valid: false; error: string } => {
+  if (!name || typeof name !== 'string' || name.trim() === '') {
+    return { valid: false, error: '名前は必須です' };
+  }
+  if (name.trim().length > MAX_NAME_LENGTH) {
+    return { valid: false, error: '名前は32文字以内で入力してください' };
+  }
+  return { valid: true };
+};
+
+/**
+ * IDのバリデーション
+ */
+const validateId = (id: unknown): { valid: true } | { valid: false; error: string } => {
+  if (!id || !Number.isInteger(id) || id <= 0) {
+    return { valid: false, error: '有効なアカウントIDが必要です' };
+  }
+  return { valid: true };
+};
+
+/**
+ * エリア配列のバリデーション
+ */
+const validateAreaArray = (area: unknown): { valid: true } | { valid: false; error: string } => {
+  if (!Array.isArray(area)) {
+    return { valid: false, error: 'エリアは配列で指定してください' };
+  }
+  for (const areaId of area) {
+    if (!Number.isInteger(areaId) || areaId <= 0) {
+      return { valid: false, error: 'エリアIDは正の整数で指定してください' };
+    }
+  }
+  return { valid: true };
+};
+
+/**
+ * キャパシティのバリデーション
+ */
+const validateCapacity = (capacity: unknown): { valid: true } | { valid: false; error: string } => {
+  if (!Number.isInteger(capacity) || (capacity as number) < 0) {
+    return { valid: false, error: 'キャパシティは0以上の整数で指定してください' };
+  }
+  return { valid: true };
+};
+
+/**
+ * PUT /api/account - メンバー情報更新
+ */
+export const PUT = async (request: NextRequest) => {
+  // 認証チェック
+  const auth = requireAuth();
+  if (!auth.ok) return auth.response;
+
+  // 管理者権限チェック
+  const adminResult = requireAdmin();
+  if (!adminResult.ok) return adminResult.response;
+
+  // リクエストボディのパース
+  let body: UpdateBody;
+  try {
+    body = (await request.json()) as UpdateBody;
+  } catch (parseError) {
+    logError('[PUT] /api/account: JSON parse failed', parseError);
+    return NextResponse.json(
+      { errors: ['リクエストボディのJSON形式が不正です'] },
+      { status: 400 },
+    );
+  }
+
+  // IDバリデーション
+  const idResult = validateId(body.id);
+  if (!idResult.valid) {
+    return NextResponse.json({ errors: [idResult.error] }, { status: 400 });
+  }
+
+  // 名前バリデーション
+  const nameResult = validateName(body.name);
+  if (!nameResult.valid) {
+    return NextResponse.json({ errors: [nameResult.error] }, { status: 400 });
+  }
+
+  // エリア配列バリデーション
+  const areaResult = validateAreaArray(body.area);
+  if (!areaResult.valid) {
+    return NextResponse.json({ errors: [areaResult.error] }, { status: 400 });
+  }
+
+  // キャパシティバリデーション
+  const capacityResult = validateCapacity(body.capacity);
+  if (!capacityResult.valid) {
+    return NextResponse.json({ errors: [capacityResult.error] }, { status: 400 });
+  }
+
+  try {
+    const res = await fetch(`${process.env.API_HOST}/accounts/${body.id}`, {
+      method: 'PUT',
+      cache: 'no-store',
+      headers: {
+        'Content-Type': 'application/json',
+        ...auth.headers,
+      },
+      body: JSON.stringify({
+        account: {
+          name: body.name.trim(),
+          area: body.area,
+          capacity: body.capacity,
+        },
+      }),
+    });
+
+    if (res.ok) {
+      try {
+        const data: unknown = await res.json();
+        return NextResponse.json(data);
+      } catch (jsonError) {
+        logError('[PUT] /api/account: Success response JSON parse failed', jsonError);
+        return NextResponse.json(
+          { errors: ['サーバーからの応答を解析できませんでした'] },
+          { status: 502 },
+        );
+      }
+    } else {
+      const errorText = await res.text().catch((err) => {
+        logError('[PUT] /api/account: res.text() failed', err);
+        return 'レスポンスボディの読み取りに失敗しました';
+      });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
+    }
+  } catch (err) {
+    logError('[PUT] /api/account', err);
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
+  }
+};

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -5,15 +5,10 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 
+import { MAX_CAPACITY, MAX_NAME_LENGTH } from '@/src/domain/constants/account';
 import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { requireAdmin, requireAuth } from '@/src/util/route-helpers';
 import { logError } from '@/src/util/safe-logger';
-
-/** 名前の最大文字数 */
-const MAX_NAME_LENGTH = 32;
-
-/** キャパシティの最大値 */
-const MAX_CAPACITY = 1000;
 
 type UpdateBody = {
   id: number;

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -89,6 +89,14 @@ export const PUT = async (request: NextRequest) => {
     );
   }
 
+  // ボディがnullまたはオブジェクトでない場合のガード
+  if (body === null || typeof body !== 'object' || Array.isArray(body)) {
+    return NextResponse.json(
+      { errors: ['リクエストボディはオブジェクト形式で指定してください'] },
+      { status: 400 },
+    );
+  }
+
   // IDバリデーション
   const idResult = validateId(body.id);
   if (!idResult.valid) {

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -34,7 +34,7 @@ const validateName = (name: unknown): { valid: true } | { valid: false; error: s
  * IDのバリデーション
  */
 const validateId = (id: unknown): { valid: true } | { valid: false; error: string } => {
-  if (!id || !Number.isInteger(id) || id <= 0) {
+  if (!id || typeof id !== 'number' || !Number.isInteger(id) || id <= 0) {
     return { valid: false, error: '有効なアカウントIDが必要です' };
   }
   return { valid: true };
@@ -141,7 +141,9 @@ export const PUT = async (request: NextRequest) => {
     if (res.ok) {
       try {
         const data: unknown = await res.json();
-        return NextResponse.json(data);
+        return NextResponse.json(data, {
+          headers: { 'Cache-Control': 'no-store, max-age=0' },
+        });
       } catch (jsonError) {
         logError('[PUT] /api/account: Success response JSON parse failed', jsonError);
         return NextResponse.json(

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -7,15 +7,20 @@ import { NextResponse } from 'next/server';
 
 import { parseErrorMessage } from '@/src/infra/http/serverClient';
 import { MemberStatus } from '@/src/types';
-import { requireAuth } from '@/src/util/route-helpers';
+import { requireAdmin, requireAuth } from '@/src/util/route-helpers';
 import { logError } from '@/src/util/safe-logger';
 
 /**
  * GET /api/accounts - メンバー一覧取得
  */
 export const GET = async () => {
+  // 認証チェック
   const auth = requireAuth();
   if (!auth.ok) return auth.response;
+
+  // 管理者権限チェック
+  const adminResult = requireAdmin();
+  if (!adminResult.ok) return adminResult.response;
 
   try {
     const res = await fetch(`${process.env.API_HOST}/accounts`, {

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -45,7 +45,9 @@ export const GET = async () => {
           { status: 502 },
         );
       }
-      return NextResponse.json(result);
+      return NextResponse.json(result, {
+        headers: { 'Cache-Control': 'no-store, max-age=0' },
+      });
     } else {
       const errorText = await res.text().catch((err) => {
         logError('[GET] /api/accounts: res.text() failed', err);

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,0 +1,55 @@
+/**
+ * Accounts API Route Handler
+ *
+ * GET /api/accounts - メンバー一覧取得
+ */
+import { NextResponse } from 'next/server';
+
+import { parseErrorMessage } from '@/src/infra/http/serverClient';
+import { MemberStatus } from '@/src/types';
+import { requireAuth } from '@/src/util/route-helpers';
+import { logError } from '@/src/util/safe-logger';
+
+/**
+ * GET /api/accounts - メンバー一覧取得
+ */
+export const GET = async () => {
+  const auth = requireAuth();
+  if (!auth.ok) return auth.response;
+
+  try {
+    const res = await fetch(`${process.env.API_HOST}/accounts`, {
+      method: 'GET',
+      cache: 'no-store',
+      headers: {
+        ...auth.headers,
+      },
+    });
+
+    if (res.ok) {
+      let result: MemberStatus[];
+      try {
+        result = (await res.json()) as MemberStatus[];
+      } catch (jsonErr) {
+        logError(
+          `[GET] /api/accounts: res.json() failed (content-type: ${res.headers.get('content-type')})`,
+          jsonErr,
+        );
+        return NextResponse.json(
+          { errors: ['バックエンドから不正なレスポンスを受信しました'] },
+          { status: 502 },
+        );
+      }
+      return NextResponse.json(result);
+    } else {
+      const errorText = await res.text().catch((err) => {
+        logError('[GET] /api/accounts: res.text() failed', err);
+        return 'レスポンスボディの読み取りに失敗しました';
+      });
+      return NextResponse.json({ errors: [parseErrorMessage(errorText)] }, { status: res.status });
+    }
+  } catch (err) {
+    logError('[GET] /api/accounts', err);
+    return NextResponse.json({ errors: ['サーバーエラーが発生しました'] }, { status: 500 });
+  }
+};

--- a/src/components/MemberCard.tsx
+++ b/src/components/MemberCard.tsx
@@ -4,6 +4,7 @@ import AssignmentIcon from '@mui/icons-material/Assignment';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import CameraAltIcon from '@mui/icons-material/CameraAlt';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
+import EditIcon from '@mui/icons-material/Edit';
 import PersonIcon from '@mui/icons-material/Person';
 import SpeedIcon from '@mui/icons-material/Speed';
 import {
@@ -29,6 +30,7 @@ import { logError } from '@/src/util/safe-logger';
 type Props = {
   member: MemberStatus;
   handleDelete: (id: number) => void;
+  onEdit: (member: MemberStatus) => void;
 };
 
 // NG率に応じた色を返す
@@ -149,21 +151,40 @@ const MemberCard = (props: Props) => {
               登録: {parseIsoToYYYYMMDD(props.member.createdAt)}
             </Typography>
           </Box>
-          <Tooltip title="メンバーを削除">
-            <IconButton
-              onClick={() => void onDelete()}
-              size="small"
-              sx={{
-                color: 'rgba(255,255,255,0.7)',
-                '&:hover': {
-                  color: 'white',
-                  bgcolor: 'rgba(255,255,255,0.1)',
-                },
-              }}
-            >
-              <DeleteOutlineIcon />
-            </IconButton>
-          </Tooltip>
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
+            <Tooltip title="編集">
+              <IconButton
+                aria-label="編集"
+                onClick={() => props.onEdit(props.member)}
+                size="small"
+                sx={{
+                  color: 'rgba(255,255,255,0.7)',
+                  '&:hover': {
+                    color: 'white',
+                    bgcolor: 'rgba(255,255,255,0.1)',
+                  },
+                }}
+              >
+                <EditIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="メンバーを削除">
+              <IconButton
+                aria-label="メンバーを削除"
+                onClick={() => void onDelete()}
+                size="small"
+                sx={{
+                  color: 'rgba(255,255,255,0.7)',
+                  '&:hover': {
+                    color: 'white',
+                    bgcolor: 'rgba(255,255,255,0.1)',
+                  },
+                }}
+              >
+                <DeleteOutlineIcon />
+              </IconButton>
+            </Tooltip>
+          </Box>
         </Box>
       </Box>
 

--- a/src/components/MemberCard.tsx
+++ b/src/components/MemberCard.tsx
@@ -29,7 +29,7 @@ import { logError } from '@/src/util/safe-logger';
 
 type Props = {
   member: MemberStatus;
-  handleDelete: (id: number) => void;
+  onDelete: (id: number) => void;
   onEdit: (member: MemberStatus) => void;
 };
 
@@ -85,7 +85,7 @@ const MemberCard = (props: Props) => {
     try {
       const result = await deleteAccount(props.member.id);
       if (result.success) {
-        props.handleDelete(props.member.id);
+        props.onDelete(props.member.id);
         showSuccess('メンバーを削除しました');
       } else {
         logError('[MemberCard] deleteAccount', result.error);

--- a/src/components/MemberCard.tsx
+++ b/src/components/MemberCard.tsx
@@ -19,7 +19,7 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
-import { memo } from 'react';
+import { memo, useCallback, useState } from 'react';
 
 import { useToast } from '@/src/context/ToastContext';
 import { parseIsoToYYYYMMDD } from '@/src/domain/functions/date';
@@ -71,26 +71,33 @@ const StatItem = ({
 const MemberCard = (props: Props) => {
   const { deleteAccount } = useAccountMutation();
   const { showSuccess, showErrorWithRetry } = useToast();
+  const [isDeleting, setIsDeleting] = useState(false);
   const ngRatePercent = props.member.ng_rate * 100;
   const ngRateColor = getNgRateColor(props.member.ng_rate);
 
-  const onDelete = async () => {
+  const onDelete = useCallback(async () => {
+    if (isDeleting) return;
     if (!confirm(`${props.member.name}を削除しますか？`)) {
       return;
     }
 
-    const result = await deleteAccount(props.member.id);
-    if (result.success) {
-      props.handleDelete(props.member.id);
-      showSuccess('メンバーを削除しました');
-    } else {
-      logError('[MemberCard] deleteAccount', result.error);
-      showErrorWithRetry(
-        result.error ?? 'メンバーの削除に失敗しました',
-        () => void onDelete(),
-      );
+    setIsDeleting(true);
+    try {
+      const result = await deleteAccount(props.member.id);
+      if (result.success) {
+        props.handleDelete(props.member.id);
+        showSuccess('メンバーを削除しました');
+      } else {
+        logError('[MemberCard] deleteAccount', result.error);
+        showErrorWithRetry(
+          result.error ?? 'メンバーの削除に失敗しました',
+          () => void onDelete(),
+        );
+      }
+    } finally {
+      setIsDeleting(false);
     }
-  };
+  }, [isDeleting, props, deleteAccount, showSuccess, showErrorWithRetry]);
 
   return (
     <Card
@@ -171,6 +178,7 @@ const MemberCard = (props: Props) => {
             <Tooltip title="メンバーを削除">
               <IconButton
                 aria-label="メンバーを削除"
+                disabled={isDeleting}
                 onClick={() => void onDelete()}
                 size="small"
                 sx={{
@@ -178,6 +186,9 @@ const MemberCard = (props: Props) => {
                   '&:hover': {
                     color: 'white',
                     bgcolor: 'rgba(255,255,255,0.1)',
+                  },
+                  '&.Mui-disabled': {
+                    color: 'rgba(255,255,255,0.3)',
                   },
                 }}
               >

--- a/src/components/MemberEditDialog.tsx
+++ b/src/components/MemberEditDialog.tsx
@@ -55,9 +55,20 @@ const MemberEditDialog = ({
       setName(editingMember.name);
       setCapacity(editingMember.capacity);
       // メンバーのエリア名からエリアIDに変換
-      const areaIds = areas
-        .filter((area) => editingMember.area.includes(area.name))
-        .map((area) => area.id);
+      const matchedAreas = areas.filter((area) => editingMember.area.includes(area.name));
+      const areaIds = matchedAreas.map((area) => area.id);
+
+      // マッピングできなかったエリア名がある場合は警告ログを出力
+      const mappedNames = matchedAreas.map((area) => area.name);
+      const unmappedAreas = editingMember.area.filter((name) => !mappedNames.includes(name));
+      if (unmappedAreas.length > 0) {
+        logError('[MemberEditDialog] エリア名のマッピングに失敗', {
+          memberId: editingMember.id,
+          memberName: editingMember.name,
+          unmappedAreas,
+        });
+      }
+
       setSelectedAreaIds(areaIds);
       setErrors({ name: null, capacity: null });
     }
@@ -182,28 +193,34 @@ const MemberEditDialog = ({
           >
             撮影可能エリア
           </Typography>
-          <FormGroup
-            sx={{
-              display: 'flex',
-              flexWrap: 'wrap',
-              flexDirection: 'row',
-            }}
-          >
-            {areas.map((area) => (
-              <FormControlLabel
-                control={
-                  <Checkbox
-                    checked={selectedAreaIds.includes(area.id)}
-                    disabled={isSubmitting}
-                    onChange={() => handleAreaToggle(area.id)}
-                  />
-                }
-                key={area.id}
-                label={area.name}
-                sx={{ flex: '1 1 calc(33.333% - 10px)' }}
-              />
-            ))}
-          </FormGroup>
+          {areas.length === 0 ? (
+            <Typography color="error" sx={{ fontSize: '0.875rem' }}>
+              エリア情報を読み込めませんでした。ダイアログを閉じて再試行してください。
+            </Typography>
+          ) : (
+            <FormGroup
+              sx={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                flexDirection: 'row',
+              }}
+            >
+              {areas.map((area) => (
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={selectedAreaIds.includes(area.id)}
+                      disabled={isSubmitting}
+                      onChange={() => handleAreaToggle(area.id)}
+                    />
+                  }
+                  key={area.id}
+                  label={area.name}
+                  sx={{ flex: '1 1 calc(33.333% - 10px)' }}
+                />
+              ))}
+            </FormGroup>
+          )}
         </Box>
 
         <TextField

--- a/src/components/MemberEditDialog.tsx
+++ b/src/components/MemberEditDialog.tsx
@@ -13,7 +13,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 import { useToast } from '@/src/context/ToastContext';
 import { MAX_CAPACITY, MAX_NAME_LENGTH } from '@/src/domain/constants/account';
@@ -51,9 +51,18 @@ const MemberEditDialog = ({
   const [selectedAreaIds, setSelectedAreaIds] = useState<number[]>([]);
   const [errors, setErrors] = useState<FormErrors>({ name: null, capacity: null });
 
+  // 初期化済みのメンバーIDを追跡（areasの再検証によるリセットを防止）
+  const initializedMemberIdRef = useRef<number | null>(null);
+
   // 初期化: ダイアログが開いたときに編集対象のデータをセット
+  // areasが再検証されても、同じメンバーを編集中ならリセットしない
   useEffect(() => {
     if (open && editingMember) {
+      // 既に同じメンバーで初期化済みならスキップ
+      if (initializedMemberIdRef.current === editingMember.id) {
+        return;
+      }
+
       setName(editingMember.name);
       setCapacity(editingMember.capacity);
       // メンバーのエリア名からエリアIDに変換
@@ -74,8 +83,16 @@ const MemberEditDialog = ({
 
       setSelectedAreaIds(areaIds);
       setErrors({ name: null, capacity: null });
+      initializedMemberIdRef.current = editingMember.id;
     }
   }, [open, editingMember, areas, showWarning]);
+
+  // ダイアログが閉じたら初期化フラグをリセット
+  useEffect(() => {
+    if (!open) {
+      initializedMemberIdRef.current = null;
+    }
+  }, [open]);
 
   const validateName = (value: string): string | null => {
     const trimmed = value.trim();

--- a/src/components/MemberEditDialog.tsx
+++ b/src/components/MemberEditDialog.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import {
+  Box,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  FormGroup,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useState, useEffect, useMemo } from 'react';
+
+import { Area, MemberStatus } from '@/src/types';
+
+/** 名前の最大文字数 */
+const MAX_NAME_LENGTH = 32;
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onSave: (name: string, areaIds: number[], capacity: number) => Promise<void>;
+  editingMember: MemberStatus | null;
+  isSubmitting: boolean;
+  areas: Area[];
+};
+
+type FormErrors = {
+  name: string | null;
+  capacity: string | null;
+};
+
+/**
+ * メンバー編集ダイアログ
+ */
+const MemberEditDialog = ({
+  open,
+  onClose,
+  onSave,
+  editingMember,
+  isSubmitting,
+  areas,
+}: Props) => {
+  const [name, setName] = useState('');
+  const [capacity, setCapacity] = useState(0);
+  const [selectedAreaIds, setSelectedAreaIds] = useState<number[]>([]);
+  const [errors, setErrors] = useState<FormErrors>({ name: null, capacity: null });
+
+  // 初期化: ダイアログが開いたときに編集対象のデータをセット
+  useEffect(() => {
+    if (open && editingMember) {
+      setName(editingMember.name);
+      setCapacity(editingMember.capacity);
+      // メンバーのエリア名からエリアIDに変換
+      const areaIds = areas
+        .filter((area) => editingMember.area.includes(area.name))
+        .map((area) => area.id);
+      setSelectedAreaIds(areaIds);
+      setErrors({ name: null, capacity: null });
+    }
+  }, [open, editingMember, areas]);
+
+  // エリア名からIDへのマッピング
+  const areaNameToId = useMemo(() => {
+    const map = new Map<string, number>();
+    areas.forEach((area) => map.set(area.name, area.id));
+    return map;
+  }, [areas]);
+
+  const validateName = (value: string): string | null => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return '名前は必須です';
+    }
+    if (trimmed.length > MAX_NAME_LENGTH) {
+      return '名前は32文字以内で入力してください';
+    }
+    return null;
+  };
+
+  const validateCapacity = (value: number): string | null => {
+    if (value < 0 || !Number.isInteger(value)) {
+      return '1日の最大撮影数は0以上で入力してください';
+    }
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const nameError = validateName(name);
+    const capacityError = validateCapacity(capacity);
+
+    if (nameError || capacityError) {
+      setErrors({ name: nameError, capacity: capacityError });
+      return;
+    }
+
+    await onSave(name.trim(), selectedAreaIds, capacity);
+  };
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      onClose();
+    }
+  };
+
+  const handleAreaToggle = (areaId: number) => {
+    setSelectedAreaIds((prev) => {
+      if (prev.includes(areaId)) {
+        return prev.filter((id) => id !== areaId);
+      }
+      return [...prev, areaId];
+    });
+  };
+
+  const handleCapacityChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10);
+    setCapacity(isNaN(value) ? 0 : value);
+    setErrors((prev) => ({ ...prev, capacity: null }));
+  };
+
+  return (
+    <Dialog
+      aria-labelledby="member-edit-dialog-title"
+      fullWidth
+      maxWidth="sm"
+      onClose={handleClose}
+      open={open}
+      slotProps={{
+        paper: {
+          sx: {
+            borderRadius: 3,
+          },
+        },
+      }}
+    >
+      <DialogTitle id="member-edit-dialog-title" sx={{ fontWeight: 700 }}>
+        メンバー編集
+      </DialogTitle>
+      <DialogContent>
+        <TextField
+          autoFocus
+          disabled={isSubmitting}
+          error={!!errors.name}
+          fullWidth
+          helperText={errors.name}
+          inputProps={{ maxLength: MAX_NAME_LENGTH + 1 }}
+          label="名前"
+          margin="dense"
+          onChange={(e) => {
+            setName(e.target.value);
+            setErrors((prev) => ({ ...prev, name: null }));
+          }}
+          required
+          value={name}
+          variant="outlined"
+        />
+
+        <Box sx={{ mt: 2, mb: 1 }}>
+          <Typography
+            color="text.secondary"
+            sx={{ fontSize: '0.75rem', fontWeight: 600, mb: 1 }}
+          >
+            撮影可能エリア
+          </Typography>
+          <FormGroup
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              flexDirection: 'row',
+            }}
+          >
+            {areas.map((area) => (
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={selectedAreaIds.includes(area.id)}
+                    disabled={isSubmitting}
+                    onChange={() => handleAreaToggle(area.id)}
+                  />
+                }
+                key={area.id}
+                label={area.name}
+                sx={{ flex: '1 1 calc(33.333% - 10px)' }}
+              />
+            ))}
+          </FormGroup>
+        </Box>
+
+        <TextField
+          disabled={isSubmitting}
+          error={!!errors.capacity}
+          fullWidth
+          helperText={errors.capacity}
+          inputProps={{ min: 0 }}
+          label="1日の最大撮影数"
+          margin="dense"
+          onChange={handleCapacityChange}
+          type="number"
+          value={capacity}
+          variant="outlined"
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button
+          disabled={isSubmitting}
+          onClick={handleClose}
+          sx={{
+            borderRadius: 2,
+            color: '#667eea',
+          }}
+        >
+          キャンセル
+        </Button>
+        <Button
+          disabled={isSubmitting}
+          onClick={() => void handleSubmit()}
+          sx={{
+            borderRadius: 2,
+            bgcolor: '#667eea',
+            color: 'white',
+            px: 3,
+            '&:hover': {
+              bgcolor: '#5a6fd6',
+            },
+          }}
+          variant="contained"
+        >
+          {isSubmitting ? '更新中...' : '更新'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default MemberEditDialog;

--- a/src/components/MemberEditDialog.tsx
+++ b/src/components/MemberEditDialog.tsx
@@ -15,14 +15,9 @@ import {
 } from '@mui/material';
 import { useState, useEffect } from 'react';
 
+import { MAX_CAPACITY, MAX_NAME_LENGTH } from '@/src/domain/constants/account';
 import { Area, MemberStatus } from '@/src/types';
 import { logError } from '@/src/util/safe-logger';
-
-/** 名前の最大文字数 */
-const MAX_NAME_LENGTH = 32;
-
-/** キャパシティの最大値 */
-const MAX_CAPACITY = 1000;
 
 type Props = {
   open: boolean;

--- a/src/components/MemberEditDialog.tsx
+++ b/src/components/MemberEditDialog.tsx
@@ -16,9 +16,13 @@ import {
 import { useState, useEffect } from 'react';
 
 import { Area, MemberStatus } from '@/src/types';
+import { logError } from '@/src/util/safe-logger';
 
 /** 名前の最大文字数 */
 const MAX_NAME_LENGTH = 32;
+
+/** キャパシティの最大値 */
+const MAX_CAPACITY = 1000;
 
 type Props = {
   open: boolean;
@@ -76,8 +80,8 @@ const MemberEditDialog = ({
   };
 
   const validateCapacity = (value: number): string | null => {
-    if (value < 0 || !Number.isInteger(value)) {
-      return '1日の最大撮影数は0以上で入力してください';
+    if (value < 0 || !Number.isInteger(value) || value > MAX_CAPACITY) {
+      return `1日の最大撮影数は0以上${MAX_CAPACITY}以下の整数で入力してください`;
     }
     return null;
   };
@@ -91,7 +95,11 @@ const MemberEditDialog = ({
       return;
     }
 
-    await onSave(name.trim(), selectedAreaIds, capacity);
+    try {
+      await onSave(name.trim(), selectedAreaIds, capacity);
+    } catch (error) {
+      logError('[MemberEditDialog:handleSubmit] onSave threw', error);
+    }
   };
 
   const handleClose = () => {

--- a/src/components/MemberEditDialog.tsx
+++ b/src/components/MemberEditDialog.tsx
@@ -114,7 +114,26 @@ const MemberEditDialog = ({
   };
 
   const handleCapacityChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = parseInt(e.target.value, 10);
+    const rawValue = e.target.value;
+
+    // 空の場合は0にリセット
+    if (rawValue === '') {
+      setCapacity(0);
+      setErrors((prev) => ({ ...prev, capacity: null }));
+      return;
+    }
+
+    // 小数点を含む場合はエラー表示（parseIntの黙示的切り捨てを防止）
+    if (rawValue.includes('.')) {
+      setCapacity(0);
+      setErrors((prev) => ({
+        ...prev,
+        capacity: `1日の最大撮影数は0以上${MAX_CAPACITY}以下の整数で入力してください`,
+      }));
+      return;
+    }
+
+    const value = parseInt(rawValue, 10);
     setCapacity(isNaN(value) ? 0 : value);
     setErrors((prev) => ({ ...prev, capacity: null }));
   };

--- a/src/components/MemberEditDialog.tsx
+++ b/src/components/MemberEditDialog.tsx
@@ -99,6 +99,7 @@ const MemberEditDialog = ({
       await onSave(name.trim(), selectedAreaIds, capacity);
     } catch (error) {
       logError('[MemberEditDialog:handleSubmit] onSave threw', error);
+      throw error; // 親のcatchで処理させる
     }
   };
 

--- a/src/components/MemberEditDialog.tsx
+++ b/src/components/MemberEditDialog.tsx
@@ -15,6 +15,7 @@ import {
 } from '@mui/material';
 import { useState, useEffect } from 'react';
 
+import { useToast } from '@/src/context/ToastContext';
 import { MAX_CAPACITY, MAX_NAME_LENGTH } from '@/src/domain/constants/account';
 import { Area, MemberStatus } from '@/src/types';
 import { logError } from '@/src/util/safe-logger';
@@ -44,6 +45,7 @@ const MemberEditDialog = ({
   isSubmitting,
   areas,
 }: Props) => {
+  const { showWarning } = useToast();
   const [name, setName] = useState('');
   const [capacity, setCapacity] = useState(0);
   const [selectedAreaIds, setSelectedAreaIds] = useState<number[]>([]);
@@ -58,21 +60,22 @@ const MemberEditDialog = ({
       const matchedAreas = areas.filter((area) => editingMember.area.includes(area.name));
       const areaIds = matchedAreas.map((area) => area.id);
 
-      // マッピングできなかったエリア名がある場合は警告ログを出力
+      // マッピングできなかったエリア名がある場合は警告ログを出力し、ユーザーに通知
       const mappedNames = matchedAreas.map((area) => area.name);
-      const unmappedAreas = editingMember.area.filter((name) => !mappedNames.includes(name));
+      const unmappedAreas = editingMember.area.filter((areaName) => !mappedNames.includes(areaName));
       if (unmappedAreas.length > 0) {
         logError('[MemberEditDialog] エリア名のマッピングに失敗', {
           memberId: editingMember.id,
           memberName: editingMember.name,
           unmappedAreas,
         });
+        showWarning(`次のエリアは選択リストにありません: ${unmappedAreas.join(', ')}`);
       }
 
       setSelectedAreaIds(areaIds);
       setErrors({ name: null, capacity: null });
     }
-  }, [open, editingMember, areas]);
+  }, [open, editingMember, areas, showWarning]);
 
   const validateName = (value: string): string | null => {
     const trimmed = value.trim();

--- a/src/components/MemberEditDialog.tsx
+++ b/src/components/MemberEditDialog.tsx
@@ -13,7 +13,7 @@ import {
   TextField,
   Typography,
 } from '@mui/material';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 
 import { Area, MemberStatus } from '@/src/types';
 
@@ -63,13 +63,6 @@ const MemberEditDialog = ({
       setErrors({ name: null, capacity: null });
     }
   }, [open, editingMember, areas]);
-
-  // エリア名からIDへのマッピング
-  const areaNameToId = useMemo(() => {
-    const map = new Map<string, number>();
-    areas.forEach((area) => map.set(area.name, area.id));
-    return map;
-  }, [areas]);
 
   const validateName = (value: string): string | null => {
     const trimmed = value.trim();

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -24,6 +24,7 @@ type ToastContextValue = {
   showToast: (message: string, type?: ToastType, duration?: number) => void;
   showError: (message: string) => void;
   showSuccess: (message: string) => void;
+  showWarning: (message: string) => void;
   showErrorWithRetry: (message: string, onRetry: () => void) => void;
   removeToast: (id: string) => void;
 };
@@ -83,6 +84,13 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
     [showToast],
   );
 
+  const showWarning = useCallback(
+    (message: string) => {
+      showToast(message, 'warning');
+    },
+    [showToast],
+  );
+
   const showErrorWithRetry = useCallback(
     (message: string, onRetry: () => void) => {
       const id = generateToastId();
@@ -105,10 +113,11 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
       showToast,
       showError,
       showSuccess,
+      showWarning,
       showErrorWithRetry,
       removeToast,
     }),
-    [toasts, showToast, showError, showSuccess, showErrorWithRetry, removeToast],
+    [toasts, showToast, showError, showSuccess, showWarning, showErrorWithRetry, removeToast],
   );
 
   return (

--- a/src/domain/constants/account.ts
+++ b/src/domain/constants/account.ts
@@ -1,0 +1,9 @@
+/**
+ * アカウント関連の共通定数
+ */
+
+/** 名前の最大文字数 */
+export const MAX_NAME_LENGTH = 32;
+
+/** キャパシティの最大値 */
+export const MAX_CAPACITY = 1000;

--- a/src/infra/http/client.ts
+++ b/src/infra/http/client.ts
@@ -60,8 +60,20 @@ export const httpClient = {
         return err(createApiError(res.status, parseErrorMessage(text)));
       }
 
-      const data: unknown = await res.json();
-      return validateWithSchema(data, options?.schema);
+      // GETは空レスポンスの場合がある
+      const text = await res.text();
+      if (!text) {
+        return ok({} as T);
+      }
+
+      try {
+        const data: unknown = JSON.parse(text);
+        return validateWithSchema(data, options?.schema);
+      } catch (jsonErr) {
+        // JSONパースに失敗した場合はエラーを返す（サイレント失敗防止）
+        logError('[httpClient.get] JSON.parse failed', jsonErr);
+        return err(createApiError(502, 'サーバーからの応答を解析できませんでした'));
+      }
     } catch (e) {
       // AbortErrorは再throwして呼び出し側でハンドリング
       if (e instanceof Error && e.name === 'AbortError') {
@@ -98,8 +110,20 @@ export const httpClient = {
         return err(createApiError(res.status, parseErrorMessage(text)));
       }
 
-      const data: unknown = await res.json();
-      return validateWithSchema(data, options?.schema);
+      // POSTは空レスポンスの場合がある
+      const text = await res.text();
+      if (!text) {
+        return ok({} as T);
+      }
+
+      try {
+        const data: unknown = JSON.parse(text);
+        return validateWithSchema(data, options?.schema);
+      } catch (jsonErr) {
+        // JSONパースに失敗した場合はエラーを返す（サイレント失敗防止）
+        logError('[httpClient.post] JSON.parse failed', jsonErr);
+        return err(createApiError(502, 'サーバーからの応答を解析できませんでした'));
+      }
     } catch (e) {
       if (e instanceof Error && e.name === 'AbortError') {
         throw e;

--- a/src/infra/http/client.ts
+++ b/src/infra/http/client.ts
@@ -170,9 +170,10 @@ export const httpClient = {
       try {
         const data: unknown = JSON.parse(text);
         return validateWithSchema(data, options?.schema);
-      } catch {
+      } catch (jsonErr) {
         // JSONパースに失敗した場合はエラーを返す（サイレント失敗防止）
-        return err(createApiError(422, 'Invalid JSON response from server'));
+        logError('[httpClient.put] JSON.parse failed', jsonErr);
+        return err(createApiError(502, 'サーバーからの応答を解析できませんでした'));
       }
     } catch (e) {
       if (e instanceof Error && e.name === 'AbortError') {
@@ -213,9 +214,10 @@ export const httpClient = {
       try {
         const data: unknown = JSON.parse(text);
         return validateWithSchema(data, options?.schema);
-      } catch {
+      } catch (jsonErr) {
         // JSONパースに失敗した場合はエラーを返す（サイレント失敗防止）
-        return err(createApiError(422, 'Invalid JSON response from server'));
+        logError('[httpClient.delete] JSON.parse failed', jsonErr);
+        return err(createApiError(502, 'サーバーからの応答を解析できませんでした'));
       }
     } catch (e) {
       if (e instanceof Error && e.name === 'AbortError') {
@@ -259,9 +261,10 @@ export const httpClient = {
       try {
         const data: unknown = JSON.parse(text);
         return validateWithSchema(data, options?.schema);
-      } catch {
+      } catch (jsonErr) {
         // JSONパースに失敗した場合はエラーを返す（サイレント失敗防止）
-        return err(createApiError(422, 'Invalid JSON response from server'));
+        logError('[httpClient.postFormData] JSON.parse failed', jsonErr);
+        return err(createApiError(502, 'サーバーからの応答を解析できませんでした'));
       }
     } catch (e) {
       if (e instanceof Error && e.name === 'AbortError') {

--- a/src/mutations/useAccountMutation.ts
+++ b/src/mutations/useAccountMutation.ts
@@ -1,13 +1,47 @@
 import { useCallback } from 'react';
 
 import { httpClient } from '@/src/infra/http';
-import { MutationErrorType, MutationResult } from '@/src/types';
+import { MemberStatus, MutationErrorType, MutationResult } from '@/src/types';
 import { logError } from '@/src/util/safe-logger';
 
 /**
  * アカウント操作用のmutation hook
  */
 export const useAccountMutation = () => {
+  /**
+   * アカウント情報を更新
+   * TYPE-006: エラー時にerrorType, statusCodeを保持
+   */
+  const updateAccount = useCallback(
+    async (
+      id: number,
+      name: string,
+      areaIds: number[],
+      capacity: number,
+    ): Promise<MutationResult<MemberStatus>> => {
+      const result = await httpClient.put<MemberStatus>('/api/account', {
+        id,
+        name,
+        area: areaIds,
+        capacity,
+      });
+
+      if (!result.ok) {
+        logError('[updateAccount]', result.error);
+        return {
+          success: false,
+          error: result.error.message,
+          errorType: result.error.type as MutationErrorType,
+          statusCode:
+            result.error.type === 'api' ? result.error.status : undefined,
+        };
+      }
+
+      return { success: true, data: result.value };
+    },
+    [],
+  );
+
   /**
    * アカウントを削除
    * TYPE-006: エラー時にerrorType, statusCodeを保持
@@ -33,6 +67,7 @@ export const useAccountMutation = () => {
   );
 
   return {
+    updateAccount,
     deleteAccount,
   };
 };


### PR DESCRIPTION
## Summary

- メンバー情報（名前、エリア、キャパシティ）の編集機能を追加
- エリア管理と同様のダイアログ形式UIパターンを採用
- MembersページをuseEffect→SWRベースに移行

## 変更内容

### API Layer
- `PUT /api/account` エンドポイント追加
- 認証・認可チェック（requireAuth, requireAdmin）
- バリデーション（id, name, area[], capacity）

### Mutation Layer
- `useAccountMutation`に`updateAccount`関数追加

### Component Layer
- `MemberEditDialog`: メンバー編集ダイアログ新規作成
- `MemberCard`: 編集ボタン追加、`onEdit` prop追加

### Page Layer
- `MembersPage`: SWRベースに移行、編集ダイアログ統合

## 新規ファイル

| ファイル | 目的 |
|----------|------|
| `src/app/api/account/route.ts` | PUT メンバー更新エンドポイント |
| `src/components/MemberEditDialog.tsx` | メンバー編集ダイアログ |
| `src/__tests__/app/api/account/route.test.ts` | Route Handlerテスト |
| `src/__tests__/app/members/page.test.tsx` | ページテスト |
| `src/__tests__/components/MemberEditDialog.test.tsx` | ダイアログテスト |
| `src/__tests__/components/MemberCard.test.tsx` | カードテスト |

## Test plan

- [x] Route Handler テスト: 21件 Pass
- [x] useAccountMutation テスト: 11件 Pass
- [x] MemberEditDialog テスト: 20件 Pass
- [x] MemberCard テスト: 11件 Pass
- [x] Members Page テスト: 11件 Pass
- [x] 全テスト実行: 842件 Pass
- [x] ESLint: 0 errors